### PR TITLE
Updates correct version format for RAC & RVM dependencies

### DIFF
--- a/BBFrameworks.podspec
+++ b/BBFrameworks.podspec
@@ -103,7 +103,7 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec "BBReactiveThumbnail" do |subspec|
-    subspec.dependency "ReactiveCocoa", "~> 2.5.0"
+    subspec.dependency "ReactiveCocoa", "~> 2.5"
     
     subspec.dependency "BBFrameworks/BBThumbnail"
     
@@ -111,8 +111,8 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec "BBMediaPicker" do |subspec|
-    subspec.ios.dependency "ReactiveCocoa", "~> 2.5.0"
-    subspec.ios.dependency "ReactiveViewModel", "~> 0.3.0"
+    subspec.ios.dependency "ReactiveCocoa", "~> 2.5"
+    subspec.ios.dependency "ReactiveViewModel", "~> 0.3"
     
     subspec.ios.dependency "BBFrameworks/BBKit"
     subspec.ios.dependency "BBFrameworks/BBBlocks"
@@ -126,8 +126,8 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec "BBMediaPlayer" do |subspec|
-    subspec.ios.dependency "ReactiveCocoa", "~> 2.5.0"
-    subspec.ios.dependency "ReactiveViewModel", "~> 0.3.0"
+    subspec.ios.dependency "ReactiveCocoa", "~> 2.5"
+    subspec.ios.dependency "ReactiveViewModel", "~> 0.3"
     
     subspec.ios.dependency "BBFrameworks/BBBlocks"
     subspec.ios.dependency "BBFrameworks/BBKit"
@@ -141,7 +141,7 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec "BBWebKit" do |subspec|
-    subspec.ios.dependency "ReactiveCocoa", "~> 2.5.0"
+    subspec.ios.dependency "ReactiveCocoa", "~> 2.5"
     subspec.ios.dependency "TUSafariActivity", "~> 1.0.0"
     subspec.ios.dependency "ARChromeActivity", "~> 1.0.0"
     
@@ -156,7 +156,7 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec "BBTooltip" do |subspec|
-    subspec.ios.dependency "ReactiveCocoa", "~> 2.5.0"
+    subspec.ios.dependency "ReactiveCocoa", "~> 2.5"
     
     subspec.ios.dependency "BBFrameworks/BBKit"
     

--- a/BBFrameworks.xcodeproj/project.pbxproj
+++ b/BBFrameworks.xcodeproj/project.pbxproj
@@ -2417,6 +2417,7 @@
 				7989C9C81B1ADE65009B1CE9 /* Frameworks */,
 				7989C9C91B1ADE65009B1CE9 /* Resources */,
 				0CB87A5B8D03521BE87F4A66 /* Copy Pods Resources */,
+				012A2B54BCD8A79EA04AF64F /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2437,6 +2438,7 @@
 				79C001081B1AD080004C9A6E /* Frameworks */,
 				79C001091B1AD080004C9A6E /* Resources */,
 				1F8305A462E2DCE7680BB77E /* Copy Pods Resources */,
+				C9B2441A817A14F907D41672 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2476,6 +2478,7 @@
 				79EA80601B3F04FE00D50B6B /* Frameworks */,
 				79EA80611B3F04FE00D50B6B /* Resources */,
 				C5680BD583642012346BF863 /* Copy Pods Resources */,
+				20A0C94A9A9C9C32F6B56288 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2532,6 +2535,7 @@
 				79EA81221B3F1E9500D50B6B /* Frameworks */,
 				79EA81231B3F1E9500D50B6B /* Resources */,
 				CABFC788CCD8975DAFC20825 /* Copy Pods Resources */,
+				AF24B2496834BA403B51DA0D /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2734,6 +2738,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		012A2B54BCD8A79EA04AF64F /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OSXDemo/Pods-OSXDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		07BFFED81B419EAF00DBC7EC /* genstrings */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2793,6 +2812,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		20A0C94A9A9C9C32F6B56288 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		71216A464C6B3FCFDBD0C18E /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2837,6 +2871,21 @@
 			shellPath = /bin/sh;
 			shellScript = scripts/./genstrings.sh;
 		};
+		AF24B2496834BA403B51DA0D /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OSXDemo/Pods-OSXDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		C5680BD583642012346BF863 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2850,6 +2899,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C9B2441A817A14F907D41672 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CABFC788CCD8975DAFC20825 /* Copy Pods Resources */ = {

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 source "https://github.com/CocoaPods/Specs.git"
 
 def common_pods
-  pod "ReactiveCocoa", "~> 2.5.0"
-  pod "ReactiveViewModel", "~> 0.3.0"
+  pod "ReactiveCocoa", "~> 2.5"
+  pod "ReactiveViewModel", "~> 0.3"
 end
 
 target :iOSDemo do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,8 +13,8 @@ PODS:
 
 DEPENDENCIES:
   - ARChromeActivity (~> 1.0.0)
-  - ReactiveCocoa (~> 2.5.0)
-  - ReactiveViewModel (~> 0.3.0)
+  - ReactiveCocoa (~> 2.5)
+  - ReactiveViewModel (~> 0.3)
   - TUSafariActivity (~> 1.0.0)
 
 SPEC CHECKSUMS:
@@ -23,4 +23,4 @@ SPEC CHECKSUMS:
   ReactiveViewModel: 58918dcbcec2d3151195ab1ed9163c57a8163999
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -13,8 +13,8 @@ PODS:
 
 DEPENDENCIES:
   - ARChromeActivity (~> 1.0.0)
-  - ReactiveCocoa (~> 2.5.0)
-  - ReactiveViewModel (~> 0.3.0)
+  - ReactiveCocoa (~> 2.5)
+  - ReactiveViewModel (~> 0.3)
   - TUSafariActivity (~> 1.0.0)
 
 SPEC CHECKSUMS:
@@ -23,4 +23,4 @@ SPEC CHECKSUMS:
   ReactiveViewModel: 58918dcbcec2d3151195ab1ed9163c57a8163999
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1554 +7,1564 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		002D3489E051E9874EAC4EEB81B1B6FF /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ADBDA7231382A4A565B27790B0730BE /* NSOrderedSet+RACSequenceAdditions.m */; };
-		00A60D23DD18B92CB6702BED01DDBD5B /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = EFE63862E8E1599ED15D1760E1765BA1 /* RACReturnSignal.h */; };
-		016F49B97B96E9C284C4497EB851DCB7 /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C99A36591AF5CB5804BAA9F521FB5E7 /* RACEXTRuntimeExtensions.m */; };
-		01BC9B6D15F61B7F3DB7234D3913CE0D /* UIActionSheet+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 15C939B20231938145B5341121598FF1 /* UIActionSheet+RACSignalSupport.h */; };
-		01C029CC1F03DB783D25DCD3A38DC9DB /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D27AD87B3E25CC9627832153765D4939 /* RACSubscriber+Private.h */; };
-		03229CB5C2C53B2EB0CB789B59786652 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3D4A780B8A8DFCB0E30FC6C2F1A0B2 /* RACSignalSequence.h */; };
-		0406D48DB4A2C3AA271FE466CA4390C0 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A05A695D82F88434D0A912EC031EE2 /* NSArray+RACSequenceAdditions.h */; };
-		04493BB4A2553AC5D92B7A9A1388E55C /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 7856AC70AFAE04D415C40B999A8567D9 /* RACErrorSignal.m */; };
-		04A801A5E7B95C14A7ECB6D1C7606417 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E039F964524B2DCBF9C0988486E8EEB /* RACKVOTrampoline.m */; };
-		04C802A4009E3F33AF734C4248209CD3 /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 8773FB8EDA1EDABE8A2C78D2D61A16AB /* RACReplaySubject.m */; };
-		04D2B3A528963CBBF353E071BCE6996C /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = A097BAAAEA31918AC85B517BD3C79DEA /* RACCommand.h */; };
-		057B5F18B203575407BA161D447513AA /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 78FCACA8F1F7541CADB0D6EE2AA02C57 /* RACImmediateScheduler.h */; };
-		0615987B7222B50AAAC39BECF79ABCEA /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D44EDB64D9F57A0D754B5B5012C1BC8 /* RACUnit.m */; };
-		072BBEECB0AF70587DCA35FD3614DC72 /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C35DBFCA5B591C7CE37DCBE48D1625C /* RACScheduler.m */; };
-		078C1796B46F28E42761B632156CDE18 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 289D0DADBC9F1F6E5EE19A5D2FE7A7E9 /* Cocoa.framework */; };
-		0812DE60AFE743FD4D9221362821EFFC /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CD013F07826A449FCBB31AB11C05472C /* RACEvent.h */; };
-		08493C44CD3B53AAAAFFAB5BF695967F /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C72957053349288966C5D4BD24E84C8 /* RACPassthroughSubscriber.h */; };
-		085490258D028398D7FA1D1346F31C7F /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B934C307FBF0D1F27BFFAAAB37ED96E /* NSURLConnection+RACSupport.h */; };
-		090615E6D5D68658B173CE5AC80933D8 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = AC72ABC92F84FC70AD5E2503BCA885B8 /* NSObject+RACDescription.m */; };
-		0931776966C3B3B534958BEA7F2791D4 /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 8773FB8EDA1EDABE8A2C78D2D61A16AB /* RACReplaySubject.m */; };
-		0C06B1EC8846131956D97C2D0670A7B2 /* Pods-iOSDemo-ReactiveViewModel-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 56B0F6DD87776B594048AEAE3FF2E706 /* Pods-iOSDemo-ReactiveViewModel-dummy.m */; };
-		0C8E11ABB9306813B96CDDA1D830EAC6 /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = B5B459CB97CF9605C48D9E36094E5CB7 /* RACEXTRuntimeExtensions.h */; };
-		0DAC6F0A835F604FBD73D9BC6951590E /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 65EE3C5478E31D18F80192C9E019DF17 /* RACDynamicSignal.h */; };
-		0DF577969B4A8022711620DECFF905ED /* NSObject+RACAppKitBindings.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0A2008D479294BC6FF776848C3C083 /* NSObject+RACAppKitBindings.m */; };
-		0E0D9022F975459DB38FB5B26155FEC1 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = BE307B8FD7B5CA8DEA04A1D6F7F8AFB2 /* RACTestScheduler.h */; };
-		0E49B00B524211E7FFC2DEE991B5D85D /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A7D8D3A7EEEB292506086DF3C3AA829 /* NSFileHandle+RACSupport.h */; };
-		0F506DBB2534ECBFF1CEC2CAFC8ED23E /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 76C7E3E32CB66CAB21651A04577BFDE2 /* RACIndexSetSequence.h */; };
-		108DA8AD7857AE0A1935E411FDE90474 /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 31A3BFE79097E1427A83176856BB8864 /* UITextView+RACSignalSupport.m */; };
-		10BC88C39BEC4900A7DBD10A51B638B9 /* UIAlertView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F91F93B244BE6B9E4C89AC52949C04E1 /* UIAlertView+RACSignalSupport.h */; };
-		117838CF30541E7549A84F0B861D57F3 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C494068064B50BA8BBF11982F37B3F12 /* NSString+RACKeyPathUtilities.m */; };
-		11D9C2AE678238BC6F2A094E260181F6 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DC827809B5D9224B71EFAEEE7560F7F /* RACSignal+Operations.m */; };
-		129F77160FF76AED71D15A0753DB6639 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 188D4EA11349A675878B1C157EAC57EC /* RACDynamicSequence.h */; };
-		12AC412E2B8023A469F1F1D9B7EA97CB /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 74C6A8D1D2A7072FC25CAE38632C18EC /* NSString+RACSequenceAdditions.m */; };
-		1349633B8FFAECD87EDBA83AA7534360 /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = B0D62EAC04D62A8F469D18ADB6E602FE /* RACEmptySignal.m */; };
-		139854AB689B7024C8FAA8AAB567C5AC /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5189B2031A207A8FA6CD5C0A66929D64 /* RACArraySequence.h */; };
-		1426916AC588B5FE2BDA5DD9564906DE /* vi.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 317B69C1A94EF8A3DD04C4FB9AC87E33 /* vi.lproj */; };
-		147D4F234044E3AA3BA319FA504A3F9C /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = CF9CE224D370EB567CAD58850C053B1C /* RACEmptySequence.m */; };
-		14D2C40D26713C03419B7A6CAC2369EC /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB823F76AF7C16F2EBC395C7D452B82 /* RACArraySequence.m */; };
-		15231E6535E8B5B5FD9DFB99540F2ECE /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CD013F07826A449FCBB31AB11C05472C /* RACEvent.h */; };
-		156CBC7A968E340E4AA8BBCFDCFAB341 /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 18DDDDE586DBD26006146C2C58919983 /* RACEagerSequence.h */; };
-		15A015A69850625D94534D99790C2329 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7961AEC15563146002A5BF0D6DF6115F /* RACKVOProxy.h */; };
-		173A58EBADA35C9BD1FC64F457314B32 /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 347410A7B054CC21BBB4EF2C83EC16B5 /* RACReturnSignal.m */; };
-		17C6FD4E5531A209C70A256175E7DEA2 /* safari~iPad@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B40B0208A1D16EA436C900B5E6834C9B /* safari~iPad@2x.png */; };
-		1817DAFDD651DF1D5C17EA1964241372 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 968B7628D7650F79B99757777F1F6B45 /* RACUnit.h */; };
-		186474497E80C27973F941FB7C13AB4D /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F485BB2CCC59F7B5B1F24EE94420556C /* NSString+RACSupport.h */; };
-		186B8774D2A3487CE34587182E894A84 /* safari-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 0514209F70FDB845FFBBB2BA42AB1B75 /* safari-7.png */; };
-		187ABCD95B74B2E3E5206C8087317665 /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EFA06C193D892B97CAAC623D521393E /* RACQueueScheduler+Subclass.h */; };
-		18CD0EBD79A3F0F0131DBC06F7EE77B9 /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A3AFFCB336D6A2A8FBE001E2BD3BB8F /* NSObject+RACSelectorSignal.h */; };
-		1A60EB03B74474473232CD8651DE4B68 /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = F04858660A0ACDD23036F70195F1F0AD /* RACSerialDisposable.h */; };
-		1B3C66DD2409D47E29ECF2342CE92112 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BFAAF0510C13BE305EDC1143245AF80 /* NSString+RACKeyPathUtilities.h */; };
-		1BBD20301BB50514BF3CBD450F8D9E68 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB5C9D377823FC29EDA1D3EE02B0696 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1BD617F3151D5BE63C36E2065F88D9EE /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = C42B476B11FC0AD93DECB928A7853D62 /* RACKVOTrampoline.h */; };
-		1C532AB8861F45DF2ECD53CEB73525DE /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6846730D0A4DAA2F536A7682FC11C5CF /* NSDictionary+RACSequenceAdditions.m */; };
-		1D936598226DDE5B8AD9FF29DEAADCC9 /* it.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 917C79F249E898193708DA61EFABDF27 /* it.lproj */; };
-		1DE7A04A4EBFE8B57BF175C52BA7E1EF /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = B5188C621CB3ACAC070ADD31784B8F68 /* NSObject+RACDescription.h */; };
-		1E10DEFD4AD626CCBFC47E1159CA7CFB /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B4CEF46ED4BEDC0BF8FD80520A060 /* RACDisposable.m */; };
-		1F136FD3CE74BA6DD4D4A6A1B325B1F5 /* UIDatePicker+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = AFA9C4124A0E2996DBBCFE875F3C60B9 /* UIDatePicker+RACSignalSupport.h */; };
-		1F1425EE1E1BFFD179DFF5C2D01545CC /* RVMViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 59AAC6F913A5EE37789B86850AAF49FC /* RVMViewModel.m */; };
-		1FD2E4791BB8DCE4FF6D745013905FA1 /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B4CEF46ED4BEDC0BF8FD80520A060 /* RACDisposable.m */; };
-		2022C651EA871FF8155DE4A401D9D638 /* RVMViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DF2EF1B391D591BAF3AED68B9C6CD4A /* RVMViewModel.h */; };
-		202F41BCA2FFE27D2A0EA595BF41BD30 /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D543B10369FF781F07957B7A26041A56 /* RACBehaviorSubject.h */; };
-		207CD65107D72AD18EE8E4702919071E /* ARChromeActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D59F02C5B74A313E1054FDB67DAC37E /* ARChromeActivity.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		21478D2D5245EAC70F783C82CBF835DB /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B3D473D1CAF17619F31AF002814899 /* RACScheduler+Subclass.h */; };
-		22590A5E851520C7BD812BAF53A1BA47 /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FA723FFA34526F62A03A19D2E204E56 /* RACStream+Private.h */; };
-		2308F61C2E899A81D07E5B2C16800628 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 197B104667FD34E79A9F68D5DA21CE11 /* RACDelegateProxy.h */; };
-		2337603C2E329819AA8015A1622EF2FF /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B8D30589207A29D93544A443730717 /* RACMulticastConnection+Private.h */; };
-		23ABDB746DDD50DC288252B251985F1A /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A085138FD85799F258E9DFFDFBC4A51D /* ReactiveCocoa.h */; };
-		23DD70C69DCF4E4AEAE439D8F6C32255 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = 5489A687C2806D8DA45E37B43109B3D0 /* NSObject+RACPropertySubscribing.h */; };
-		2400225244487B000FA192785D9671D6 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB5C9D377823FC29EDA1D3EE02B0696 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		242206D245C06F71F082CB7F80AAA085 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C494068064B50BA8BBF11982F37B3F12 /* NSString+RACKeyPathUtilities.m */; };
-		24A88225238EE6CD2EAD5B675F8BAB62 /* Pods-iOSDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0447E5038A8FFAE26550600D09F65E8D /* Pods-iOSDemo-dummy.m */; };
-		24C21BCAA9D6D5A7D032007A11461D07 /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B0750FD4759F28C8D918027C7C238616 /* RACStream.m */; };
-		24F861853DA13D7FB6EBEFA21D4083FC /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = DD5D0F6CABD12A493055F2BE8D9FF91F /* RACIndexSetSequence.m */; };
-		257DD208AB2103E51A400E95C4EDE3E6 /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = E6D3799F93F2F7A590C79FCB070DE22C /* RACSubscriptionScheduler.m */; };
-		2620ED8A661CB605A5912C97E95BF0D0 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = B1B8861A6B229F818BCE2EC17ECEA114 /* RACSignalProvider.d */; };
-		26D2B6F2423C1D9C1858201D01EE5F10 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 24A8C000C2435C5362CBC8986C8B5773 /* NSNotificationCenter+RACSupport.h */; };
-		2705564EB9AC9D2D28B27EB45CC3BCA8 /* UIControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D4340B272F3EE69DFBCFE995319DF31 /* UIControl+RACSignalSupport.h */; };
-		27F7DF084F86D1FA892C253F869E4DB0 /* safari-7~iPad.png in Resources */ = {isa = PBXBuildFile; fileRef = 86645EB49F8FB75B21E8306B02878A72 /* safari-7~iPad.png */; };
-		28267F1768EAB54408E429A9CF5266C6 /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = F018065A9386572D09E5322F0115945E /* NSObject+RACLifting.m */; };
-		2A80214D1D0E013ACC9CD4E623DEA431 /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A7D8D3A7EEEB292506086DF3C3AA829 /* NSFileHandle+RACSupport.h */; };
-		2AA222C5565955BAB01C36EC85A18C98 /* Pods-OSXDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E1F9B1B9A7F6D58C8C3B39A6FF22D496 /* Pods-OSXDemo-dummy.m */; };
-		2BF96EACD387B86EA66414E83CBFACFB /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6846730D0A4DAA2F536A7682FC11C5CF /* NSDictionary+RACSequenceAdditions.m */; };
-		2C264B5C8F6776CDE6538A836DCCEB2E /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B8C27EA6E4BFED387A9E1B3123825B0 /* RACImmediateScheduler.m */; };
-		2D16FE43A7E0CD71D2F3120A370200A3 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3925C05522371D1E4E40F4AE5795282E /* MKAnnotationView+RACSignalSupport.h */; };
-		2D40B189FA309BD848794351DD899909 /* UIControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 278695DD4B5B44CDADB306E87A50D151 /* UIControl+RACSignalSupport.m */; };
-		2DC97FBB131A1BB341BCC5E6ADE269A6 /* TUSafariActivity-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F1B9802B73E4DA17207F8CD37A39FE5 /* TUSafariActivity-dummy.m */; };
-		2E09607764F22EE25BE69BBC6D06C320 /* UIStepper+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 44CA503643A7653AC1AEA112A4323D9D /* UIStepper+RACSignalSupport.m */; };
-		2E77177C311D4E4217B83333D757E455 /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ADBDA7231382A4A565B27790B0730BE /* NSOrderedSet+RACSequenceAdditions.m */; };
-		2EE06B881C7DAD4A68ADD633178D7363 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 4257FEA86FA90F2B77C7278E29858092 /* RACEmptySequence.h */; };
-		2F16045AABBA3D96BC4865FB94381EDF /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 46AC114C2E3CBA44EB74C95EC0C59360 /* RACStream.h */; };
-		2F2080BD405753BCF3C77726B3517A49 /* UIActionSheet+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 265A63E9272E1C7B27874A0898146FA0 /* UIActionSheet+RACSignalSupport.m */; };
-		2FAF50D2DED11CE239E00AC3A0212F1E /* UISlider+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D1044CE4AC4CE6AE373041E3567AC9F /* UISlider+RACSignalSupport.h */; };
-		31776600E1AF84911E105433370B75A3 /* safari@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 81259BB9DD6807FF7905E6C94FC4D0C6 /* safari@2x.png */; };
-		321289F34B72864D84E033AC0F4D0C16 /* UISlider+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D07C4A22E4B34D3CA20F749A5BB3627A /* UISlider+RACSignalSupport.m */; };
-		32D4F57BAFC0C0377A4914C474B87002 /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D48ADC77497F585ADCB941D1F0B0029F /* RACBlockTrampoline.m */; };
-		337A04D7DA99DB2B7084AAA7EEC3E0F8 /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 90148881F051DCFFF1A83F567E2F0339 /* RACScheduler.h */; };
-		34420854E398DE1B4211EA0AFDB821D1 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 9272A08E478EFC8956C985469864CCC7 /* RACSerialDisposable.m */; };
-		3456EBC6A9BAC672A7222FB6D1C97D48 /* ReactiveViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = DDFB2D8D994759171B928C0C62A09628 /* ReactiveViewModel.h */; };
-		353047E3787B39E04953351A446E5F89 /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 293C9029DA0B2225C8096D4A9AEE0949 /* RACmetamacros.h */; };
-		358C0B9F49097C9C519881411E648693 /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 96FC8B8E155AC9762A2AFB38667B41A0 /* NSIndexSet+RACSequenceAdditions.m */; };
-		35F467AA9DCBEB04B93864B269939385 /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E4841A2F2258085854D3651DD1C78D3 /* NSSet+RACSequenceAdditions.h */; };
-		368688BC2E9E45C3FDEC0D6E33491588 /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A3AFFCB336D6A2A8FBE001E2BD3BB8F /* NSObject+RACSelectorSignal.h */; };
-		3727665E40202CD58BC375C84FE880C4 /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 73B3FCC97278A75478097B6CC0768F90 /* NSFileHandle+RACSupport.m */; };
-		390378F7FDAFBDC8D488435761C82982 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A9A4E2B6F473FBB306154C442E6FD9AD /* RACSubscriptionScheduler.h */; };
-		3A4322957DB1AC11E113DDC151F76D2D /* RVMViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 59AAC6F913A5EE37789B86850AAF49FC /* RVMViewModel.m */; };
-		3CAFA3851C6C5F9F530A20AB4775D198 /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5189B2031A207A8FA6CD5C0A66929D64 /* RACArraySequence.h */; };
-		3EAC3FC2559E7E7974E9E1E5C1CE1FE5 /* nl.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 2B3A51FA14C49CBAE314B9D403F44B23 /* nl.lproj */; };
-		3F09A134D74FA9FB4AC9E04C13F7401A /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 25D4CC1B6651C94C90A57E1DF2A80EB1 /* RACStringSequence.m */; };
-		3F8143B1D72FCCEA91F6D1CE52910960 /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = AF18C68853CE72E437DFBC85139F5431 /* RACObjCRuntime.h */; };
-		3F98BAF69199D79F3CAA177C178E42A3 /* NSText+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DFB677FA0CF9D2064F007BB1FB12AFF /* NSText+RACSignalSupport.h */; };
-		403223EC2378D663121C376E1AC3D088 /* NSObject+RACAppKitBindings.h in Headers */ = {isa = PBXBuildFile; fileRef = 7287809267EFD8915EE4B6D61DE460C3 /* NSObject+RACAppKitBindings.h */; };
-		415F2DB36E839CC8D6FEA9C313C2A086 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ED934E6B939034E1577D7B0A469707D /* UITableViewHeaderFooterView+RACSignalSupport.h */; };
-		42DBE946489C3AC45B9A44AB09739B8C /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 958D014BD521F902010219C7B9A93B0B /* RACValueTransformer.m */; };
-		431CDBBF65B533BE1B6E03DBB5709430 /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 65EE3C5478E31D18F80192C9E019DF17 /* RACDynamicSignal.h */; };
-		43E08FF1C4B455FD6D5A8E5FBD5625DC /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = FDF9280BE17056BFCBB44C11A3F7C0B3 /* RACReplaySubject.h */; };
-		44403C605B6A1121251D7E3B0D8FAB6A /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A50CB73B740D29B17FCBB116B6665E9 /* RACEvent.m */; };
-		4517FDB1EFD1AA7935156F45B31EE0C5 /* pt.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 53E2B0BCDB0E396BF7DDA641486794BB /* pt.lproj */; };
-		45BEC210EF759751A63751FDEE440C42 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02AB9A3D8C18D72585A9345858E3951C /* RACMulticastConnection.h */; };
-		46204EF42F007AA3376624E522CEC9A0 /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 958D014BD521F902010219C7B9A93B0B /* RACValueTransformer.m */; };
-		4A2CF3158F9AFAF457058A3A394E2EEE /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB9A46F76CA8D03A47DB02342073CCB7 /* RACScheduler+Private.h */; };
-		4A34CDAE3007A4C3DF47874C1FDE128A /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 17A9C9D0CFDFC9414CCB422577B05CB0 /* NSOrderedSet+RACSequenceAdditions.h */; };
-		4B1149024DAE066B4D85CC1C138A3C28 /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E4F67358DF287E33B991CD7D35C08 /* RACKVOChannel.h */; };
-		4B775DF18FFF140F096EE8FEC1184D1D /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B9643DB88DE3F7C350CA02DB559AF182 /* RACSequence.m */; };
-		4C61BD8AB9C6ECCF8245E2B17C95E8BE /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC8652C1E7FCFDDA8BF8790D9B7F54E /* RACPassthroughSubscriber.m */; };
-		4EDF95D86C801D5FA857B842B8CB1F9B /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 003E242E42E67E7B590471A1B061D103 /* NSURLConnection+RACSupport.m */; };
-		502AB5C7F4D7F1F4A3AFB9AA211C89BD /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4C49DE77E3F848A81F428F34E79463 /* RACGroupedSignal.h */; };
-		50A6DD77E62565139B4A97F71415518A /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 6637492CC2B364C39D40D5351D972947 /* RACCompoundDisposableProvider.d */; };
-		5124D10978D2BEE748E643598031E884 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DE386ED3892B3192E2AA1E3E04029B5 /* RACScopedDisposable.m */; };
-		5186936C592D5714199ECE1DB1600694 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = CDB021FA2483DA1E9E846A0C737FA8A6 /* RACCompoundDisposable.m */; };
-		5201CA441C97B17FC769E9534D1C4FE9 /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E88B0ADFBF294D399B6F67BBAE3BEB27 /* NSString+RACSequenceAdditions.h */; };
-		548994209D74FAF2D7DBDF70C31226AA /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B3D473D1CAF17619F31AF002814899 /* RACScheduler+Subclass.h */; };
-		54C739CF8556F30D05403B6E2165DB39 /* UITextView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E5B2EFE7FE8D884045E8A92FFF76F2A4 /* UITextView+RACSignalSupport.h */; };
-		552C3A8041B24FB88A8A54D791A310CF /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 25D4CC1B6651C94C90A57E1DF2A80EB1 /* RACStringSequence.m */; };
-		556689D907BD2318C9A3B1103DC16807 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 289D0DADBC9F1F6E5EE19A5D2FE7A7E9 /* Cocoa.framework */; };
-		558ACB4B737AD26BD593B2CFC8836B30 /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 293C9029DA0B2225C8096D4A9AEE0949 /* RACmetamacros.h */; };
-		5600C7479571AEF4E8A7D6A2357127A2 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 3059F2F2EBECE984FA730D95BCD35958 /* RACTupleSequence.h */; };
-		56249E483277365EEA12EEF83E4A1290 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BDEE4AEB45BD91ED2AC28A8136D436A /* RACDelegateProxy.m */; };
-		566C1171A33AEE996DB4464D59073E99 /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 17A9C9D0CFDFC9414CCB422577B05CB0 /* NSOrderedSet+RACSequenceAdditions.h */; };
-		57D2CC7CF91AD6BD2B0E503DBB5C2D2D /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEFE70E9171906FCD1DC5624071DEFC /* RACQueueScheduler.h */; };
-		57D4556B5A226EAD075D8BD52DF5BC3E /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86CE32DE04525C8C4C27F140E6FBB82A /* RACSignal.h */; };
-		58DC920E152FCEC9877C0B09B7118A76 /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = B5B459CB97CF9605C48D9E36094E5CB7 /* RACEXTRuntimeExtensions.h */; };
-		58E2099595058B2B538BD5712C529606 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */; };
-		58ED09797CBA8D881B4C57A3DAE9070B /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BDEE4AEB45BD91ED2AC28A8136D436A /* RACDelegateProxy.m */; };
-		59205438CFA54DFBD538213AFD769C1A /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 46AC114C2E3CBA44EB74C95EC0C59360 /* RACStream.h */; };
-		59360E9F2C848D894D421C10A7FEDDCC /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B82CBB7E3811E1ABDB91CC76A2CE1DF4 /* NSUserDefaults+RACSupport.h */; };
-		59EA3B5F4771927A62DA8444AA9148C6 /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = AC122118585236D0F4DA3B10C1245C66 /* NSData+RACSupport.h */; };
-		5A442B61AA317A209D7AD157ED3AD064 /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CC845AB300C07D951F6F71237265BF /* RACEXTScope.h */; };
-		5B19E9F553D40A4387E9C712BC46680A /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = 831687FB5D10486613F3DA0B61A46C70 /* NSObject+RACDeallocating.h */; };
-		5B226AE321F1481E9CE4E7C45521FC39 /* de.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 2EE58839D3A596AA8AD1E3C331D506F6 /* de.lproj */; };
-		5B3C2F91DA7BC335753CF3B36BFBA727 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = B4781EF1C6C2425DA7FF8C11B0FE4567 /* RACSubscriber.m */; };
-		5D605B5FD603E10D9EB566636A5F92E7 /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F8F5C9B68C93238892F0A78C3D6A6D /* UITableViewHeaderFooterView+RACSignalSupport.m */; };
-		5E247D85EF76F3EA6216A0816180D0CF /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E852CFF7297852B9ACBE5B41503CA2 /* RACValueTransformer.h */; };
-		5EDA2D13B1C038D12A386C3DDC73B3D4 /* UITextField+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 78CD3D7A3E70AB0C7A651F66C9978667 /* UITextField+RACSignalSupport.m */; };
-		5EEDF0E415F27F1CD7170E80D4A1A53E /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED77FF9159C7E09FE907DB65F51B251 /* RACGroupedSignal.m */; };
-		5F55A260E7BE6B6D9D706ED1A7B6C3EB /* cs.lproj in Resources */ = {isa = PBXBuildFile; fileRef = F4ACFFD726DE98F952D2715A8FE904C3 /* cs.lproj */; };
-		5F7CD4512FAB26E8A61754C56D1A6C59 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = DB3482F070F513F530E64649A484F827 /* UIBarButtonItem+RACCommandSupport.m */; };
-		5F910A10642EE0D81046263F6CE3B4D3 /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = F018065A9386572D09E5322F0115945E /* NSObject+RACLifting.m */; };
-		603A6F2AD8463DD5A8AB4F3A817C06D4 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F99F0A6FFDB81788747F8A3171C270A /* RACSubscriber.h */; };
-		61537EE153DE1B933FCB2C554B3A51D7 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 72E83AE4CD7EED36A7C6347CE4378C27 /* RACEXTKeyPathCoding.h */; };
-		61CC7DF5E59A708B021ECBF7300D5096 /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 09B6B1659018C794FCB6E287462BC8B2 /* NSData+RACSupport.m */; };
-		61DD6A0CDEACB60D3A56DF1901FF54AA /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C2798FF9D596802406300C7E8723BA /* RACQueueScheduler.m */; };
-		6415BB2C3C56A0BFA1B6BFB1081F3AFC /* UICollectionReusableView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC2EF9D9154E68ED17F779DA1915E8B /* UICollectionReusableView+RACSignalSupport.h */; };
-		6432ABC2E70B87561FCEF4365B926777 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4324ABDECD6CDE80EE4D42B3ED108293 /* RACChannel.h */; };
-		64AC1BAC5E63902EA5970C58B60E2A3F /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = 831687FB5D10486613F3DA0B61A46C70 /* NSObject+RACDeallocating.h */; };
-		662E0805BD85C32F854E04F394C50BD0 /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BC3F321D5887C075F31139B5975DFA72 /* UIGestureRecognizer+RACSignalSupport.m */; };
-		665228B606AC8A081AFD45F85A352095 /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = DE451BE988A97C4BD2DF85BAA4177D9D /* NSInvocation+RACTypeParsing.h */; };
-		66EDD672FE974B3900B6AE9380DA3503 /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 90148881F051DCFFF1A83F567E2F0339 /* RACScheduler.h */; };
-		672D443E574E3ACA073A29435FC37125 /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86CE32DE04525C8C4C27F140E6FBB82A /* RACSignal.h */; };
-		67B678D7C3A6217D6C6CB871BE13EDF7 /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE24908E1DD76F05BE3BFD1156B95CD /* NSObject+RACLifting.h */; };
-		6808C9C4E595422AB2BA2D2C0A516351 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DC827809B5D9224B71EFAEEE7560F7F /* RACSignal+Operations.m */; };
-		68FC4095C6D86C69EF29CC8D6E85D8B0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */; };
-		6949F58AC8D3A616B14B2320185BEE23 /* eu.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 20A5943D7F6A92BA8A48314327AB2516 /* eu.lproj */; };
-		6B7D8418D8B55752964991AB9E5B7B3D /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D543B10369FF781F07957B7A26041A56 /* RACBehaviorSubject.h */; };
-		6C2F36A14C0763502BE3E64D3FBF2C65 /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F9A475AFF0BFD5183F7EF312078B2E /* RACEmptySignal.h */; };
-		6C6F9D2ACF5BA753183CB71133558343 /* en.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 2CC01C0141A3E749870A67763348DF74 /* en.lproj */; };
-		6C7D27EA92FF3225C850AB08765EFAA3 /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F2FC7FE2ECDAD999DC1FF54627A29B1 /* NSArray+RACSequenceAdditions.m */; };
-		6CB05727FB2BE08C0E1D76835750FF8C /* NSControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 949E114381CFA92E910684B8BEAB0E59 /* NSControl+RACCommandSupport.h */; };
-		6F08D63908A4D1483109564BEC8226C3 /* Pods-OSXDemo-ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A06A3A96FB9D289AB191978F0589B50E /* Pods-OSXDemo-ReactiveCocoa-dummy.m */; };
-		6F38E0ACA3D75CFCB2F7D6A027C61D09 /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B934C307FBF0D1F27BFFAAAB37ED96E /* NSURLConnection+RACSupport.h */; };
-		707A37736BF00CEF31D572183BE7A32C /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F89EAD6445D20525C6617CDCF40E18 /* RACScopedDisposable.h */; };
-		72D1F3B119F627A080C0C594967963DB /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E852CFF7297852B9ACBE5B41503CA2 /* RACValueTransformer.h */; };
-		734F81C14662936D563F4F434CD0AEA6 /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BBD58C3874DD439EBCCAC57098AE21 /* RACSequence.h */; };
-		7374554BB665EC3CCDE8506DC4EA0779 /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EEC199A454683642D9A27AB1E9B77C /* RACBlockTrampoline.h */; };
-		73FCD525B57C27216D637C608E9C7FE1 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = C8CA520F048665D31F25988E787189B9 /* RACTestScheduler.m */; };
-		74689BFD73699C0FC0D352BF738F2D14 /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C72957053349288966C5D4BD24E84C8 /* RACPassthroughSubscriber.h */; };
-		746D2AE75D2513359D8328DE78CC8F46 /* NSControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C8C498C43C287C5F801A31F393EA6D30 /* NSControl+RACCommandSupport.m */; };
-		757600B75F80A11E85E80A9082068D44 /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 93C536457A6D4A275CAF5E8BC886DD77 /* RACBehaviorSubject.m */; };
-		766A04896B6B9CBD04F8D1B4C412213D /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EFA06C193D892B97CAAC623D521393E /* RACQueueScheduler+Subclass.h */; };
-		776CD064D02C6FDE953B12402CEAE2B9 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F69AD0A69C7E7090F19429598DD17BB6 /* RACErrorSignal.h */; };
-		77F0A13A96C01843151AC16CE2D020B4 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D81C0467590F8EE5A3FC23E4B050F45D /* RACChannel.m */; };
-		784084870DBA84549B3E67EA95E62C5E /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = B5188C621CB3ACAC070ADD31784B8F68 /* NSObject+RACDescription.h */; };
-		78B41F2EB6656B1ADCC3A41C2DF542F5 /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB9A46F76CA8D03A47DB02342073CCB7 /* RACScheduler+Private.h */; };
-		791B8CD50DC9EDB2AE033570BFA0B99C /* UISegmentedControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D2D0E557458973ED0022FE510725842 /* UISegmentedControl+RACSignalSupport.h */; };
-		797C09FC1CCEC867881296F3CFD1D42A /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CBBAA78ABC4464F0DF879FE45A3C3759 /* MKAnnotationView+RACSignalSupport.m */; };
-		7A61D0EB0DB34E5CD63B50827B78BE5D /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E20C597B94D0683ECED7071C31C4A7 /* NSObject+RACPropertySubscribing.m */; };
-		7A6362EB95723806AAFFAAC4BE134312 /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C2798FF9D596802406300C7E8723BA /* RACQueueScheduler.m */; };
-		7B206881D7FA6BC12B1165D9EBAD10F7 /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5180C63571ACBAA2A7DB11B1A290A09A /* RACTupleSequence.m */; };
-		7CB1A664AA35AB2155EA43EBAAB35DA4 /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D44EDB64D9F57A0D754B5B5012C1BC8 /* RACUnit.m */; };
-		7CD3466C4C8D03BA23B5FE1B212268EE /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 1363FC19E200CE140654E63C0DDB6662 /* RACEagerSequence.m */; };
-		7D01D534CB92D79878192D9F734F0881 /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEFE70E9171906FCD1DC5624071DEFC /* RACQueueScheduler.h */; };
-		7D5DCB21E92772BED46E263A07A08B94 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A9A4E2B6F473FBB306154C442E6FD9AD /* RACSubscriptionScheduler.h */; };
-		7DD41EC24DCBF7F396DFBF4F8142B140 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8989322B3B83978F83AD7CB0361A34A1 /* NSSet+RACSequenceAdditions.m */; };
-		7DD692C6CBA1A44CBC8E54F38FCEECAE /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFE052DA2259F4D29680A0F0F37B73D /* RACDynamicSignal.m */; };
-		7ECD272EC3D16EDF624708D777557B66 /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B8D30589207A29D93544A443730717 /* RACMulticastConnection+Private.h */; };
-		7F3FECA299EC0E6F29E43B25A4793B3D /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B8C27EA6E4BFED387A9E1B3123825B0 /* RACImmediateScheduler.m */; };
-		7F44A7E67C750567A53EF36439B09DED /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 74C6A8D1D2A7072FC25CAE38632C18EC /* NSString+RACSequenceAdditions.m */; };
-		7FBF984A2E3D9511FB781D05AFC8E535 /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5180C63571ACBAA2A7DB11B1A290A09A /* RACTupleSequence.m */; };
-		811D3706743EE1DB1C6BCFBF2EFA6DAE /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 81FB5BCF7A667679A3A31516968CAED2 /* NSObject+RACKVOWrapper.m */; };
-		81CFC2E6CD6CF66068FEECECCE69B7A5 /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C2599E17B9A70EDB8547A831B50BD0 /* RACTargetQueueScheduler.m */; };
-		823475E8574289913CE5A2D88EE7F69A /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D27AD87B3E25CC9627832153765D4939 /* RACSubscriber+Private.h */; };
-		8289878B1171A0100814DC1537DA6C4F /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = EA79360878BC8A37BA63762482E52EE1 /* RACSubscriptingAssignmentTrampoline.h */; };
-		829A03BA36217086818BC4440F3095BE /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = C6EAE038798890FDE806B30250E09DAD /* RACCompoundDisposable.h */; };
-		82D6099BC1B35DC92EE2662633E4CEFE /* NSControl+RACTextSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 272BAE73358159A37442D7A772BC9C76 /* NSControl+RACTextSignalSupport.h */; };
-		839DCF276758CECC61663FC7EED52811 /* UIRefreshControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F19E5E21542A06A70630A9CB46E48761 /* UIRefreshControl+RACCommandSupport.h */; };
-		83C3370A6598B30A43E29704588C0771 /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = F04858660A0ACDD23036F70195F1F0AD /* RACSerialDisposable.h */; };
-		8401A2B0C18B7EF200918EB2919E67F6 /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B9441D0CEFAB6891A4BD48BFA9A0DD90 /* NSUserDefaults+RACSupport.m */; };
-		8465CD9D4D357BC77A83BB2BAA6E8EFA /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = D7F88AEE42657D472B2992F29311B85C /* RACCommand.m */; };
-		855D7F11881230499C48D1361350A782 /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B18349B085B61E9C4B610A155E031748 /* NSNotificationCenter+RACSupport.m */; };
-		8565585705C62F10FE4B1D2DF37F3737 /* UISegmentedControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A349EB05ED550FE9CE77FD2B20C35BC0 /* UISegmentedControl+RACSignalSupport.m */; };
-		8587AC50F1FB7BCB3164A975D6CEE2DB /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 968B7628D7650F79B99757777F1F6B45 /* RACUnit.h */; };
-		85F44CD4CB38F89998891334482D78F6 /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = AC122118585236D0F4DA3B10C1245C66 /* NSData+RACSupport.h */; };
-		866E794287AE79890D07FEBD6B69DB58 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 943F9021136C30FD9BC0FE238FEDCA94 /* NSIndexSet+RACSequenceAdditions.h */; };
-		86AD0BD722B5476F5C58047DA9519D47 /* UITableViewCell+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3BEAC6E02413CE43B98E3A3482C2BA /* UITableViewCell+RACSignalSupport.h */; };
-		86B8F575CDDE4A082BA338C4391E5F92 /* zh_CN.lproj in Resources */ = {isa = PBXBuildFile; fileRef = E098CE032BC1EAF0A0AB6A2E19EDE2D7 /* zh_CN.lproj */; };
-		8727109DCE6355A2DB820477358956D3 /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = AF18C68853CE72E437DFBC85139F5431 /* RACObjCRuntime.h */; };
-		8772AD04525BC05EE86202F61EC37CA9 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 15D14F53D043C5F0D3F9EB867E7D3FDA /* RACSignal.m */; };
-		8794403DE81BAA6D46C0B1139D64281B /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = CDB021FA2483DA1E9E846A0C737FA8A6 /* RACCompoundDisposable.m */; };
-		87A56A8FB110B1B28CCE8A083334F5CA /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D1AEECD7595E35FEBC1CFD08D1B8E5AA /* RACKVOChannel.m */; };
-		87E21073ED0BB4578EE1388EB54C9187 /* fi.lproj in Resources */ = {isa = PBXBuildFile; fileRef = F23AAEFCF552C6430E5A77A17BF89206 /* fi.lproj */; };
-		880D15B375B3B6F260CAC870A88E7F84 /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BBD58C3874DD439EBCCAC57098AE21 /* RACSequence.h */; };
-		8819594680C6EC439F9F988CC8BC31C6 /* safari-7~iPad@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 66766A6D1C81A945DAB83EFFA4EFCA16 /* safari-7~iPad@2x.png */; };
-		885D0FA049C69D63421D643106005C45 /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = 03BDBC76E6B2BC3A7BA3276FD0D2F068 /* NSInvocation+RACTypeParsing.m */; };
-		885E685B4CF13BDAF6F9250C1B4F6BC2 /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = CF9CE224D370EB567CAD58850C053B1C /* RACEmptySequence.m */; };
-		89134E6CD08DDA0F41335E400BCB318E /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = DD5D0F6CABD12A493055F2BE8D9FF91F /* RACIndexSetSequence.m */; };
-		8A20843217CBA1F7196B770057AFDBBB /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 93C536457A6D4A275CAF5E8BC886DD77 /* RACBehaviorSubject.m */; };
-		8D885CD777E0FFC71E7EF0DDD5C25F7A /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0567CDE373FFE56F0E721BE120EB1E95 /* RACSubject.h */; };
-		8EF4F113DA7EA4EFB309A886408709BD /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E4F67358DF287E33B991CD7D35C08 /* RACKVOChannel.h */; };
-		8FC0803F7EEBBE253C5D040884AEDE6F /* RVMViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DF2EF1B391D591BAF3AED68B9C6CD4A /* RVMViewModel.h */; };
-		9019E7B277D7B81603056B6222AFE103 /* safari-7@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3E73BADC9E8D63779CB79360C0F84B89 /* safari-7@2x.png */; };
-		904AECD6E46F1606E9355F0EBBEE89CB /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02AB9A3D8C18D72585A9345858E3951C /* RACMulticastConnection.h */; };
-		9115324E017318936E8ABCEF8B9269E8 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = B4781EF1C6C2425DA7FF8C11B0FE4567 /* RACSubscriber.m */; };
-		91635254E7BFA5D6A3FCF52C9F92D8A9 /* NSText+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 17DBCD15D00C9DA12A3DAE0AB7469B56 /* NSText+RACSignalSupport.m */; };
-		927681125672B1F0D9966162632CC512 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B9643DB88DE3F7C350CA02DB559AF182 /* RACSequence.m */; };
-		92A82669DD165A87EE36F0EDAAA3B8C6 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = BE307B8FD7B5CA8DEA04A1D6F7F8AFB2 /* RACTestScheduler.h */; };
-		9341656E020859732F1B50384ABA6043 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 3059F2F2EBECE984FA730D95BCD35958 /* RACTupleSequence.h */; };
-		9511BCB9002D4284E6D5A1A5373684DA /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CC070D947F559BC5A3222915ABE78CD /* NSObject+RACKVOWrapper.h */; };
-		956C243D00CA6A064877B971360EF8CB /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C2599E17B9A70EDB8547A831B50BD0 /* RACTargetQueueScheduler.m */; };
-		95940732B05B192087C25387E4768309 /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = C05A51FD36FDD375DFE9198B8B0FF259 /* RACStringSequence.h */; };
-		963D1D4CE575F7DF1EED85570ABB9EC8 /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 78FCACA8F1F7541CADB0D6EE2AA02C57 /* RACImmediateScheduler.h */; };
-		9707BA6E5F087ECDFDEAA73F08DAA857 /* UISwitch+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F20FD0A8EDF787FA061448C874715155 /* UISwitch+RACSignalSupport.h */; };
-		97144CBDCBF24BB8AFE2A6FEF9F6CE74 /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 16F9A475AFF0BFD5183F7EF312078B2E /* RACEmptySignal.h */; };
-		971E6122F7390754E84C6E29EE13F44B /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E88B0ADFBF294D399B6F67BBAE3BEB27 /* NSString+RACSequenceAdditions.h */; };
-		977DE2B63690BA6ABCABB0FF6CA0BE54 /* UISwitch+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A802CA6FA3D8A8488065C6B1378DB7B6 /* UISwitch+RACSignalSupport.m */; };
-		97960449617CE1E817CD64C5A5BB5347 /* ja.lproj in Resources */ = {isa = PBXBuildFile; fileRef = C8B4E1B576455BF39FE0A5053F83000C /* ja.lproj */; };
-		97E13D8C628AAD4923C9790A2C0263E5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */; };
-		984580B34E1D361D38E786B726B363F0 /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CC070D947F559BC5A3222915ABE78CD /* NSObject+RACKVOWrapper.h */; };
-		9864D9AD767819D076CAE3B737291F61 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B82CBB7E3811E1ABDB91CC76A2CE1DF4 /* NSUserDefaults+RACSupport.h */; };
-		99EF50AB9148D56963E5BD4F2DEFF198 /* NSControl+RACTextSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D2050276400F6EB01867BAD68FB2E1A0 /* NSControl+RACTextSignalSupport.m */; };
-		9A0D890AE82146430B84C92E033959C2 /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 347410A7B054CC21BBB4EF2C83EC16B5 /* RACReturnSignal.m */; };
-		9BCFEE39AE69B50A2B088BB8AC9A116D /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = A190EEABE930390FB1404033B0E34352 /* RACSignalSequence.m */; };
-		9C4778D1D001A6917C0F9D72861F2A47 /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D1AEECD7595E35FEBC1CFD08D1B8E5AA /* RACKVOChannel.m */; };
-		9EBF6A835072B8C0FDB0F9BD05CB8FD5 /* sv.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 142369E5E72C70E19E4EB45CE716AA80 /* sv.lproj */; };
-		A0EC6CF4B3706D18E86AAF8BB3C97215 /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFE052DA2259F4D29680A0F0F37B73D /* RACDynamicSignal.m */; };
-		A127ADC6C5B2804648CC319B37150750 /* UIControl+RACSignalSupportPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0167F063CC719C0E1682227664568F58 /* UIControl+RACSignalSupportPrivate.h */; };
-		A15B4EA76D7F4A845BE387F89AA246EC /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7961AEC15563146002A5BF0D6DF6115F /* RACKVOProxy.h */; };
-		A2A5238C209B39E6E88D936564B5DD92 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E039F964524B2DCBF9C0988486E8EEB /* RACKVOTrampoline.m */; };
-		A3CB732301F1FF93F429489A41AB29EC /* ru.lproj in Resources */ = {isa = PBXBuildFile; fileRef = FE850AFB1F3120138D61FDBE9B17A05E /* ru.lproj */; };
-		A520EC6CD4D05B61422686C5D025E5DD /* TUSafariActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 78E363F84E058AE357AA0EDAA2EEB566 /* TUSafariActivity.h */; };
-		A52122DB4216D6D4525FBCFAA88105E4 /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = EA79360878BC8A37BA63762482E52EE1 /* RACSubscriptingAssignmentTrampoline.h */; };
-		A5CB23F880C916C1EA78643DE622FC6B /* UIAlertView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 886D59625C86AA324B6184EF0649CA6F /* UIAlertView+RACSignalSupport.m */; };
-		A696D009737EAF3A58AC327900B43AB5 /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 003E242E42E67E7B590471A1B061D103 /* NSURLConnection+RACSupport.m */; };
-		A71D21CFDEFA68989CFFD9426D642506 /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = FDF9280BE17056BFCBB44C11A3F7C0B3 /* RACReplaySubject.h */; };
-		A7673271D54761D066C4C225EB224DDC /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 54BCEF405EA3B7D1B643D1ABC8CA1C5A /* RACKVOProxy.m */; };
-		A93A50967991F1B591481C48349BEA25 /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EEC199A454683642D9A27AB1E9B77C /* RACBlockTrampoline.h */; };
-		AADA6698017F790577C7A63129A5991E /* Pods-OSXDemo-ReactiveViewModel-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BDA197270DE813CD77C9978D2DAEF369 /* Pods-OSXDemo-ReactiveViewModel-dummy.m */; };
-		AB2FD2992B7019E2FEDD8DC50D377963 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */; };
-		AB3873104821F25BA0C8EADB50843B85 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = 5489A687C2806D8DA45E37B43109B3D0 /* NSObject+RACPropertySubscribing.h */; };
-		AB6D3C2DC614C4FD5F998F2D7AE721B8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */; };
-		ABD827397762B410A562EAB26622F46E /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 9272A08E478EFC8956C985469864CCC7 /* RACSerialDisposable.m */; };
-		AD06B728EA8B22ACCE2528EFE3902F0C /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0935FDF3A822645B87AC32ACEAD9F1EB /* RACSubject.m */; };
-		AD576D97EA33BEEBF18DB84EBE63BAEE /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 7057D8040E6E22620A32A1A4125D991C /* RACSubscriptingAssignmentTrampoline.m */; };
-		ADD80F2E8E93EB481C2DDB245E47A32E /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FA723FFA34526F62A03A19D2E204E56 /* RACStream+Private.h */; };
-		AFA47FEFC8BE34D16C061A9F202D07C5 /* UIButton+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EC49D13C8ABF07761F08B8E25C133C /* UIButton+RACCommandSupport.h */; };
-		AFF06078503F5F85FF115ED3961F4F98 /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED77FF9159C7E09FE907DB65F51B251 /* RACGroupedSignal.m */; };
-		B03A6ADC353F6FECF76C17FD00694FFB /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 8879B7353BAD1C287FC4ACDC3DAC37A2 /* RACDynamicSequence.m */; };
-		B0B5BD38DA80F741CF970FE9D851DC3F /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = DE451BE988A97C4BD2DF85BAA4177D9D /* NSInvocation+RACTypeParsing.h */; };
-		B0DB5DC033163E4A2F85840B43A3831F /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FC799242719D2C5809E8D041BCF339E /* NSString+RACSupport.m */; };
-		B2AC038BFB8B570773E3AE00A246F736 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 24A8C000C2435C5362CBC8986C8B5773 /* NSNotificationCenter+RACSupport.h */; };
-		B2F1F82197273DAD5B02A643A23588AC /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 943F9021136C30FD9BC0FE238FEDCA94 /* NSIndexSet+RACSequenceAdditions.h */; };
-		B305A27EC919C81E6A226F1417DDEB5A /* safari@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2AA16D46D4D749459B908DA762C0E8D1 /* safari@3x.png */; };
-		B4BFCF617407BFFDEED4DF0425FF1265 /* safari.png in Resources */ = {isa = PBXBuildFile; fileRef = 138A1DABBD9576D0FDB48C429147149D /* safari.png */; };
-		B4C2FFD73393B8C1260A3034A478CFD1 /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = C05A51FD36FDD375DFE9198B8B0FF259 /* RACStringSequence.h */; };
-		B60E619CED2D37BE2BCE83E5E4403A99 /* UIDatePicker+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = FCF7EA8B6B5063BCB47DAA1613D288FF /* UIDatePicker+RACSignalSupport.m */; };
-		B6287869B8933BA3B736BC0BAE908FFA /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = C42B476B11FC0AD93DECB928A7853D62 /* RACKVOTrampoline.h */; };
-		B6F407C2288F4FFEC08DEC2B4CDF2A99 /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5879B8B48431419CE4AF8720DD96176A /* NSDictionary+RACSequenceAdditions.h */; };
-		BA6C6493B4B1440EB1F5B354525F8D52 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 81FB5BCF7A667679A3A31516968CAED2 /* NSObject+RACKVOWrapper.m */; };
-		BB0AB72535E3A565B6AAE1F42C463673 /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5DD6C875E236D9328F2AF10B590C11 /* RACUnarySequence.h */; };
-		BC9D7EA2C9BB609F3A8531E646E74D9D /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 16764EA1D4AA994848588AEE13511ABC /* NSEnumerator+RACSequenceAdditions.h */; };
-		BE5E746F53EF357AF3AE84F3346F8FF4 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = B8EED562581C016F20A615D17793A422 /* RACTuple.h */; };
-		C016893182083F85648A960EC3D11546 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = C8CA520F048665D31F25988E787189B9 /* RACTestScheduler.m */; };
-		C0BA3DCD1621E156227E83D035594149 /* UITableViewCell+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 973754C87D63265F338926EA6894018D /* UITableViewCell+RACSignalSupport.m */; };
-		C19B9324E6BAADA953F7CC5D1B902476 /* pl.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 2638C213F8CF918A737ABC1649BAAAD4 /* pl.lproj */; };
-		C2C168015D8DDD9ACA11CF4C8CDA1482 /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC8652C1E7FCFDDA8BF8790D9B7F54E /* RACPassthroughSubscriber.m */; };
-		C2EE1B133983B3924285B7C892C99604 /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 75D7D01A90BECF813F328A2DA082DB42 /* RACDisposable.h */; };
-		C2F2BB5F291AF0A0C7DD2D3427245374 /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F485BB2CCC59F7B5B1F24EE94420556C /* NSString+RACSupport.h */; };
-		C2F6597E8A77EF42E0C6AE6CD67518B4 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FC799242719D2C5809E8D041BCF339E /* NSString+RACSupport.m */; };
-		C31303999473485CB4C1889841B0AC95 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 72E83AE4CD7EED36A7C6347CE4378C27 /* RACEXTKeyPathCoding.h */; };
-		C32705A6FF471E130AD9747DA6E666E6 /* no.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 8971DC9D6EAB1D6AAAE39C537BC0AC23 /* no.lproj */; };
-		C403206ECB36613696634981FA5CABA8 /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CC845AB300C07D951F6F71237265BF /* RACEXTScope.h */; };
-		C4E42A26D5A8809612C050D1A1C95B03 /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4C49DE77E3F848A81F428F34E79463 /* RACGroupedSignal.h */; };
-		C50E26ED8DE1891C98BE9CDDA2A229BA /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 7856AC70AFAE04D415C40B999A8567D9 /* RACErrorSignal.m */; };
-		C5B8654296CE5155598AC8EBA0ECC98A /* ko.lproj in Resources */ = {isa = PBXBuildFile; fileRef = F37E0664305307657AFE92692D44B60E /* ko.lproj */; };
-		C627DA54DCC6B160BA9C3BDBA04BD379 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A085138FD85799F258E9DFFDFBC4A51D /* ReactiveCocoa.h */; };
-		C65C85058D4BBBE6459AF09D0686C225 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F69AD0A69C7E7090F19429598DD17BB6 /* RACErrorSignal.h */; };
-		C66C858E6E5C113C9EF63441A4D10964 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8989322B3B83978F83AD7CB0361A34A1 /* NSSet+RACSequenceAdditions.m */; };
-		C785C1665E7C61D86C2B000F05729FEF /* safari-7@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = CD5382D0ACA18ABC23819294F2F32123 /* safari-7@3x.png */; };
-		C7C8BBBE26B9BB6D6E6954BEA0467C9A /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 96FC8B8E155AC9762A2AFB38667B41A0 /* NSIndexSet+RACSequenceAdditions.m */; };
-		C80F28354C4ED7249222C2A16E1E0E6A /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 73B3FCC97278A75478097B6CC0768F90 /* NSFileHandle+RACSupport.m */; };
-		C92E9058DA17C47D7CF947000356349D /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BFAAF0510C13BE305EDC1143245AF80 /* NSString+RACKeyPathUtilities.h */; };
-		CACFCC5E22C6D22263860902E0E9A481 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A05A695D82F88434D0A912EC031EE2 /* NSArray+RACSequenceAdditions.h */; };
-		CB03CC766ACEF4029B0E4A202E249774 /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 39235E7CBD2CA2BB9EA7CABEA3B918D9 /* RACMulticastConnection.m */; };
-		CB4120FB5F2327FC47C6DCD3D598F06D /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C35DBFCA5B591C7CE37DCBE48D1625C /* RACScheduler.m */; };
-		CB4465476C2B51D2D300D1589CC97E50 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3D4A780B8A8DFCB0E30FC6C2F1A0B2 /* RACSignalSequence.h */; };
-		CB468A02004838FB2E7554B8CB0F7B46 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 66D59063E166FE928FE993BCC3BE236B /* NSObject+RACSelectorSignal.m */; };
-		CBC4DA6DC2D7336D352E8A3ED4532581 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = C6EAE038798890FDE806B30250E09DAD /* RACCompoundDisposable.h */; };
-		CC440CB4F1FCBBB64A3174300604957E /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B9441D0CEFAB6891A4BD48BFA9A0DD90 /* NSUserDefaults+RACSupport.m */; };
-		CC87593D2856E1E7CE681BC8A1AB6C42 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB823F76AF7C16F2EBC395C7D452B82 /* RACArraySequence.m */; };
-		CC91DF85A57E66D95F2DD4EEBAC72616 /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E20C597B94D0683ECED7071C31C4A7 /* NSObject+RACPropertySubscribing.m */; };
-		CC9A3BBA5E5A08F8AC0E336668F43467 /* es.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 0DC326BC82862EFA1620E6C3A7E35213 /* es.lproj */; };
-		CD109B8928865058119F6505B12261E1 /* UICollectionReusableView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = EE008F0470C6E65A6125B07D4D9288A8 /* UICollectionReusableView+RACSignalSupport.m */; };
-		CE671A84CA5EEE5ADAFC3B7E2D53F470 /* UIGestureRecognizer+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = ECAE97031F73CD25E5B79FF2A0A35462 /* UIGestureRecognizer+RACSignalSupport.h */; };
-		CF2EC65E53B0DB0092BBAF9344D1E310 /* ARChromeActivity-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DAF5A464A2AEA238D8C9013006524F0 /* ARChromeActivity-dummy.m */; };
-		CF4C09E6F0F582644A94DD51D8156B53 /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = B0D62EAC04D62A8F469D18ADB6E602FE /* RACEmptySignal.m */; };
-		CF6C8D0AD9A098BC05A82A2E80A9DCD4 /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 6637492CC2B364C39D40D5351D972947 /* RACCompoundDisposableProvider.d */; };
-		D05B15062D6EC62434415D39EAD941BA /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = B9919FA09FC18EF187A3F988C6102903 /* RACTargetQueueScheduler.h */; };
-		D29397B60DE7492B190522ED637CCA4E /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = CEEB6CE9BFE79CB52095223105869FD5 /* NSObject+RACDeallocating.m */; };
-		D30F2A8DAF43D8053FA7E6BE5408EF92 /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE24908E1DD76F05BE3BFD1156B95CD /* NSObject+RACLifting.h */; };
-		D4474BA95B4F27C3BB8B2F3FC980BF1D /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 75D7D01A90BECF813F328A2DA082DB42 /* RACDisposable.h */; };
-		D628C3A73116FD49317FFFF7C0C6411B /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = EFE63862E8E1599ED15D1760E1765BA1 /* RACReturnSignal.h */; };
-		D77E407FFC5AF9212A67A35021F23286 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E5736DBD756980A7BABA839F5B636 /* RACUnarySequence.m */; };
-		D86E5A0E6561B3ED90F2D55857C6F9EF /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C31631E8EF0A85EEB6534D32B617F0E /* RACTuple.m */; };
-		D9DF45E4CFADE4215DBD963759E8A88D /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = A097BAAAEA31918AC85B517BD3C79DEA /* RACCommand.h */; };
-		DA099B72FFA334F3C58A032A07FFDABD /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = E6D3799F93F2F7A590C79FCB070DE22C /* RACSubscriptionScheduler.m */; };
-		DBAE21DAA93A065D4EDA26E9C72016DA /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 1363FC19E200CE140654E63C0DDB6662 /* RACEagerSequence.m */; };
-		DD36AC2518D5ADF1D3686F32774E80FA /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = B9919FA09FC18EF187A3F988C6102903 /* RACTargetQueueScheduler.h */; };
-		DD390F41741FA4BBD4A7E96C3E641D01 /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BE1D100E476FF9FDB4D86278F848CA3 /* UIBarButtonItem+RACCommandSupport.h */; };
-		DD53650F3F73D5955D52D5FC17DD4171 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 15D14F53D043C5F0D3F9EB867E7D3FDA /* RACSignal.m */; };
-		DDE1387E5E0954505C499A85508E2374 /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 18DDDDE586DBD26006146C2C58919983 /* RACEagerSequence.h */; };
-		DE116BE715A8223321B5CECEF6572CE0 /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5879B8B48431419CE4AF8720DD96176A /* NSDictionary+RACSequenceAdditions.h */; };
-		DE1B201210DC99DE14B077F06CEB8040 /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C99A36591AF5CB5804BAA9F521FB5E7 /* RACEXTRuntimeExtensions.m */; };
-		DF5997806E1FAF0BAFD193F4A55D6F86 /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 09B6B1659018C794FCB6E287462BC8B2 /* NSData+RACSupport.m */; };
-		DFA1EB0D313655F58AB1A785831818F9 /* ARChromeActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = B6411D8038636F4B27F0FFFCA810C0D7 /* ARChromeActivity.h */; };
-		DFBA9E3E2394C57C223A9567ABA154D1 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = B1B8861A6B229F818BCE2EC17ECEA114 /* RACSignalProvider.d */; };
-		E006465E24C7D37A06DD18D3A1A2E908 /* TUSafariActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 477DFED5355D2A19F8C1D874513C0734 /* TUSafariActivity.m */; };
-		E18C5220051DBD13D1228C8D9DC69BAA /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D400F363D8EA6A70892C39ACFE82D97 /* RACSignal+Operations.h */; };
-		E1AE899E237F3F7D95192D335829133C /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C8E5736DBD756980A7BABA839F5B636 /* RACUnarySequence.m */; };
-		E2B4499601411FBACF8BAA68DDDD6DB5 /* UIRefreshControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 52FFAEBE948518482803379C80F8A38D /* UIRefreshControl+RACCommandSupport.m */; };
-		E31B75AC69BE523CFC734C8406E84487 /* UIButton+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 88840275991F5A2C7F87BDF4FF477026 /* UIButton+RACCommandSupport.m */; };
-		E3559B5A2F8700C70193A319EF0F8C93 /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = 03BDBC76E6B2BC3A7BA3276FD0D2F068 /* NSInvocation+RACTypeParsing.m */; };
-		E45C47D87A7B53A0D0D85744421C6A8E /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D48ADC77497F585ADCB941D1F0B0029F /* RACBlockTrampoline.m */; };
-		E472D8D121FEC08A524BF042B12FCB77 /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F2FC7FE2ECDAD999DC1FF54627A29B1 /* NSArray+RACSequenceAdditions.m */; };
-		E4A0569C284D1C19B3FF97C682FB6F99 /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = B0750FD4759F28C8D918027C7C238616 /* RACStream.m */; };
-		E56F45D27E1B6BAE156119CC2884C500 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = B8EED562581C016F20A615D17793A422 /* RACTuple.h */; };
-		E5AD7ADFA627E1F283A66D7D2D3F1FA6 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = A190EEABE930390FB1404033B0E34352 /* RACSignalSequence.m */; };
-		E5B3ABE3E19F94D666BC495F04217F1A /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = AC72ABC92F84FC70AD5E2503BCA885B8 /* NSObject+RACDescription.m */; };
-		E5C2EB542C61158CFF3E0A684CD3614E /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 54BCEF405EA3B7D1B643D1ABC8CA1C5A /* RACKVOProxy.m */; };
-		E5C346A98DA2EEDAB3022FAF40CDE944 /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F89EAD6445D20525C6617CDCF40E18 /* RACScopedDisposable.h */; };
-		E5F0D20923C38AE82F45DF7C5AA31DFD /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = D7F88AEE42657D472B2992F29311B85C /* RACCommand.m */; };
-		E5FD189A074EAE11ABFDE8D6AA6BDCF1 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 4257FEA86FA90F2B77C7278E29858092 /* RACEmptySequence.h */; };
-		E6170D09B4A04587B9467ACAA593FA84 /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A50CB73B740D29B17FCBB116B6665E9 /* RACEvent.m */; };
-		E6B30429146096C2DEECB96B7DAA914F /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 76C7E3E32CB66CAB21651A04577BFDE2 /* RACIndexSetSequence.h */; };
-		E795D5CF2F8EE77627C7BFE4AD545E46 /* safari~iPad.png in Resources */ = {isa = PBXBuildFile; fileRef = D2F35B878B8E6E79BED2280C1749AEBB /* safari~iPad.png */; };
-		E7DE07D4798D08611ADE1EF1A4047EBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 7EADC9D8C9636E0994AB340660AF1CAF /* fr.lproj */; };
-		E867576364DD77C1712CC865F84CAA1A /* ReactiveViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = DDFB2D8D994759171B928C0C62A09628 /* ReactiveViewModel.h */; };
-		E8826EBCD866C86241B0E2725615798A /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4324ABDECD6CDE80EE4D42B3ED108293 /* RACChannel.h */; };
-		EA1099414E9768ECEA5FF2D74407B3C0 /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = CEEB6CE9BFE79CB52095223105869FD5 /* NSObject+RACDeallocating.m */; };
-		EA882855D24A42656BC9E00143F110AB /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D400F363D8EA6A70892C39ACFE82D97 /* RACSignal+Operations.h */; };
-		EB2DF82B5F37DE4C2B8EB5B1C56FFF38 /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0935FDF3A822645B87AC32ACEAD9F1EB /* RACSubject.m */; };
-		EB4B41B7329030EDB64235231E663E72 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 7057D8040E6E22620A32A1A4125D991C /* RACSubscriptingAssignmentTrampoline.m */; };
-		EC0F98CCD35E83CBB321D6778905E0AA /* UIControl+RACSignalSupportPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3428AFDB0B65A20D06339592AF1D9AEB /* UIControl+RACSignalSupportPrivate.m */; };
-		EC38403AE69F0AEE5E0D4434938721F8 /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 8879B7353BAD1C287FC4ACDC3DAC37A2 /* RACDynamicSequence.m */; };
-		ECE9E3CA4B700D4B62934DEA5F0BCC1C /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 16764EA1D4AA994848588AEE13511ABC /* NSEnumerator+RACSequenceAdditions.h */; };
-		EEEA30926D1743F6DBC91CF26044CEDC /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B18349B085B61E9C4B610A155E031748 /* NSNotificationCenter+RACSupport.m */; };
-		F0019F0AE8D6D8F3AE7D391FFACC9068 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 81E98B187F4F5D954A297B69765400C3 /* NSEnumerator+RACSequenceAdditions.m */; };
-		F09B1D17E2693D8CC36351A5B5AEC66B /* sk.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 49492D834246297A7CF98C30CEA2A556 /* sk.lproj */; };
-		F1DAB34BAE13BC6AF2E8BC69FB97D83F /* UIImagePickerController+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 40E5E0E6357BD0D0AC1C2C13C550346B /* UIImagePickerController+RACSignalSupport.h */; };
-		F200241FC463934796295CB3447B3983 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 289D0DADBC9F1F6E5EE19A5D2FE7A7E9 /* Cocoa.framework */; };
-		F2150743B0677F0655DB36B820A007A6 /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E4841A2F2258085854D3651DD1C78D3 /* NSSet+RACSequenceAdditions.h */; };
-		F278549D9459D74676807AB45B8EC2BF /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 81E98B187F4F5D954A297B69765400C3 /* NSEnumerator+RACSequenceAdditions.m */; };
-		F2D432F6D3AED58B095DE065518FC1E9 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DE386ED3892B3192E2AA1E3E04029B5 /* RACScopedDisposable.m */; };
-		F3E234812FD4E9062A09DB4A298A44B0 /* UITextField+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 72758B728D8AB6C632836340DCD900DE /* UITextField+RACSignalSupport.h */; };
-		F4791343A5F49F0A2BDD342D9F8711DE /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0567CDE373FFE56F0E721BE120EB1E95 /* RACSubject.h */; };
-		F4B87E3C5BCBD97019343224FC0D7F97 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D81C0467590F8EE5A3FC23E4B050F45D /* RACChannel.m */; };
-		F52F543CEE31C49C214060DA0DC7D1D1 /* Pods-iOSDemo-ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EFF6773BDB5919C49059D46FFC988AA /* Pods-iOSDemo-ReactiveCocoa-dummy.m */; };
-		F550E3ED05A826A5A9C4FE790737F66C /* UIStepper+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = DD39CA030B4599162C3E822EB80CBC33 /* UIStepper+RACSignalSupport.h */; };
-		F654A3B54ED61A3675AF5339669325C4 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 66D59063E166FE928FE993BCC3BE236B /* NSObject+RACSelectorSignal.m */; };
-		F8016BAB7AE47A7E4AFA4C1D8B04AE6F /* UIImagePickerController+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = F73BBFE23390E4C468B17EA660A986A8 /* UIImagePickerController+RACSignalSupport.m */; };
-		F81849FF166E4B69915729698BFCB179 /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C31631E8EF0A85EEB6534D32B617F0E /* RACTuple.m */; };
-		FB511AD6FAEB27A798A15FDD60C19B9F /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 39235E7CBD2CA2BB9EA7CABEA3B918D9 /* RACMulticastConnection.m */; };
-		FC41C5E3FE258CE62356EB1406DF1C28 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F99F0A6FFDB81788747F8A3171C270A /* RACSubscriber.h */; };
-		FCE3535857F5A9727FE6F3FF085A8F72 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 197B104667FD34E79A9F68D5DA21CE11 /* RACDelegateProxy.h */; };
-		FE63DE280C4EBB32FF37F122FF462C7A /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5DD6C875E236D9328F2AF10B590C11 /* RACUnarySequence.h */; };
-		FF6D4EA9855CF8927AB7B5A196B5F632 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 188D4EA11349A675878B1C157EAC57EC /* RACDynamicSequence.h */; };
+		0054563BECE53687979682A26062D839 /* UITextView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1564204204A9EA7E397A5928E13DDF19 /* UITextView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01B8481BF91BF0313617CF7EE607169F /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 54862ADDA9043F400532C3DD8D77360E /* fr.lproj */; };
+		0302A7EBA990666865590C424951A987 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = E5BE3BA2C5DC6C49534DE219797AC9E8 /* RACTestScheduler.m */; };
+		036C7CB2EE1806F298618AFE3ADB1A8A /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = C270D701D6F4B96200E26E366825A467 /* NSInvocation+RACTypeParsing.m */; };
+		041545D81916E3127A24D121CE29A4A2 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 425CFFAA98530C1BFB112FCF22298B1E /* RACErrorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05BA564B7980A8207B2ED73134FCFD6D /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 97AB17BC5CF27F73DCBF21298655B330 /* RACEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		063A8C8A125507FA74A196DEF4845D2F /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 709639233E1017FC9678B5D70FFA2292 /* NSObject+RACSelectorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06733EE679BFF3F529E284A190EECEBB /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DD55019777DFDAA80710EF4DB635ACA /* RACEmptySequence.m */; };
+		08486FFC4688445A70751BB8C5DF83F9 /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 98FA579B637755D52A4505EE262FDE9C /* RACArraySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		08B7A4E3A4B8BC1969A08F7A730443A2 /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 617968821460F8AC471D89413A9DF24C /* RACEagerSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0936D261C1B7D307897FBB7C76A4421A /* UIActionSheet+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 38414290241A098A8827B0B39859EEB6 /* UIActionSheet+RACSignalSupport.m */; };
+		0C08A3DB08203BA94EAEE779DF272D4E /* UIControl+RACSignalSupportPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = A320927BAAE1EA13F662AC3CC75B6EBE /* UIControl+RACSignalSupportPrivate.m */; };
+		0D24F2CA17585B61583E401CB328555B /* UIImagePickerController+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = FED1C042F67A7F13B7F72BA35A22C091 /* UIImagePickerController+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D2967C848E2DEEF5C51F04A22F0FB6C /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = 36270DE5D71EF8CBE60C877DA756B83D /* NSObject+RACPropertySubscribing.m */; };
+		0E7BBA23020A8A755DA9DB36EAA7F662 /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = F787BB2D65C142FF059BC79EEF0F70AA /* RACEvent.m */; };
+		0FA7C0CB2B5D20E8B68B0D374D236E69 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = FEB614E55CB1AE19C3A5916F1E2E356E /* RACSignalProvider.d */; };
+		0FE7065CBE46CD422B9563E4178D17E3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */; };
+		103587B2B6492C05C5F673E5DDB1DF9F /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = EAB16CEA3E3AD133D8C5B60DFFF408D5 /* RACSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10CDDC5A0AED376486AB1D2E649FA544 /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = FE8FE679B677A7E6F7086E8A464613C1 /* RACCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10DF8E468309FC91E98B82CFA6ECAD3B /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CDED8AE31BDD914BEB8740875B4A18C /* UITextView+RACSignalSupport.m */; };
+		1169746444DC0CFE6EAE759113ADE83C /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A42591629D201EFB7229A3E3725E0FE /* RACUnarySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1255E1BC4545714AD6C18BDB01731813 /* UIControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = F43876A9FCC13C6A90F3D8A47EA50B5F /* UIControl+RACSignalSupport.m */; };
+		1267DCAB237F5C0793FAB87C8447C343 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 208B63F2B8CBA2F1604B2B19B90E445B /* RACKVOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		129E9504478EC529D4C5AFC24D57A94B /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E500123DAEA08E61707389A7FAFC1AA /* NSData+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		12C113A535AA7DDB89CD9186340418AA /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 34571FAB0B24C9F9D1B040892BF6E9F9 /* RACSubject.m */; };
+		140EB2328856617C96FB1B75331901FC /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = EDB801CEAA8D8921F02950E802201161 /* RACDynamicSequence.m */; };
+		14A60FC439668778788BDCE110678F59 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E71ED0750C26510E6B897F643D5444F /* NSString+RACKeyPathUtilities.m */; };
+		14D70549A53F7FBF39AFA4B6B3BA97A3 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B8473348A056B38B0C59FE8AE7903883 /* NSSet+RACSequenceAdditions.m */; };
+		15710646D26A63C065D68497A52EC049 /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = 36270DE5D71EF8CBE60C877DA756B83D /* NSObject+RACPropertySubscribing.m */; };
+		160FB69D2279467D55AE76EA11D4AE4E /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 73C34C61A1F72050F3A764015E301663 /* RACBlockTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1687336A349D0889758BBECE1770F88A /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = E5BE3BA2C5DC6C49534DE219797AC9E8 /* RACTestScheduler.m */; };
+		1863DF7E62D1D88D72D4A5134BA28FF8 /* NSControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = A95C2AF877BDB7D5F87CE30D15799955 /* NSControl+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		188448872FF61B3640F3906ABC170F79 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CC39B61678940382A63A47C01EECD74E /* RACDelegateProxy.m */; };
+		1888F14D1C9E665A81759BBCD7687997 /* RVMViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 961458246F38388E8FC56D87653532B5 /* RVMViewModel.m */; };
+		19C384DEA5FB7487299A66B30FF06EAA /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4510C24033F59D6991A5646B7E160400 /* RACScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A2F652199094E601A31A268DCDEAEA9 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D1145FCAFD92D8CA5612CA6A935B5E /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A3935E07B4DDAAFB6A737EA96D1291A /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F63902A4D80BF8C416E9A4F486CCD98 /* RACTuple.m */; };
+		1A6816A49F5D7503A3665E159503330F /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 752BABCDFA9B041845F7EDEB8439A73D /* RACStream.m */; };
+		1B472340BB445CBEE517A2E2E472A5B6 /* pt.lproj in Resources */ = {isa = PBXBuildFile; fileRef = FA59FE4BFF0BCFDCEC7729C529DCA9BD /* pt.lproj */; };
+		1CEAC508AB0142AF1085EB60C742B963 /* UIRefreshControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 30E13086600B1F4EA03B6EEDB29077BE /* UIRefreshControl+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D7E48190225C92343750181BCE26079 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D35AE7E8B8140FF1B365B76FFEFE /* RACSerialDisposable.m */; };
+		1FA9C0A40D4FF4736CCB3D0B2836C24D /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F4A160440A8B2FF8B2B6B06ACF1B684 /* NSDictionary+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		20F60B92AEDCF6CDBE9AF94E8C6EF551 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE25DD04263CA735DBC0065D686C708D /* Cocoa.framework */; };
+		215CA1078AD1ED82B0435AE8C2333FB3 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 87B69D4A64EACE4F90F282AE61E7C383 /* RACUnarySequence.m */; };
+		21A4BD1AFD36021317D47301AAF37A5A /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = AEFD11FFA22306403DAE6070F4AC59D1 /* RACKVOChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21AF34D94354912663DD0086A6FEC5A9 /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 469B9F12809631BD28D225E7F4BA9674 /* RACReplaySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21B8AE9423C113CB4F62679F7BFACB99 /* UIDatePicker+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DCAF96FE449F756C7AE83F57E520DBB /* UIDatePicker+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2250E5AFBE2DFE8691C39EE2A5797D0A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE25DD04263CA735DBC0065D686C708D /* Cocoa.framework */; };
+		2281CD54778EF4A840BBDFD0830372BC /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = A711C6C1895952B4A0ED343E892FE407 /* RACStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		22E68008D356F1B7538753EDB2DB82A2 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F544DB0ACE3BB3689704BDA915E425 /* MKAnnotationView+RACSignalSupport.m */; };
+		2384DDDEC3E77EF78389A3E9AE7149DC /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C2149B8B2DEA7D2F2CAE26324D19A /* NSArray+RACSequenceAdditions.m */; };
+		24A380008046FAACA7AD0D04A85D68C9 /* NSText+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = C023BADA5CEDAA037E32E7E73B35E716 /* NSText+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		24CF86B96F6D3C307C99ECED886427E7 /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F0044387D70A7AF1345FD32DEE471E9 /* RACEmptySignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		263C0F41EDBC2D971CA86BB63B0B875D /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F5482872801818DA8BC1667FDAB0EEF /* RACTupleSequence.m */; };
+		2644AE63C581B71C12C339D49AEE594E /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A52E0AF777D3E19A75BE97CDC841BA /* RACStream+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		27279CB0452CC5AC00EC5787E3F8A6C0 /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F63902A4D80BF8C416E9A4F486CCD98 /* RACTuple.m */; };
+		27C150EF073A8A7E236D1BB43EBBC072 /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 47FEDFB3D989A901B9E35C29DA7460AB /* RACSerialDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		288A103C2AA2BEB68308475F7CC30328 /* UIControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = C9367045BB3B2BBFCB5B7595E1F4BD08 /* UIControl+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		28BFD228FCB04083C816B81FE1A35D20 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A329D816C2F2213778D9939A93331319 /* NSArray+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		29195FC3DDCD37E3345A93CE67170A0A /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AD0BF205524EC06E486E117887EB76F /* RACGroupedSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2937873E2105062E9047C28EC8BA1B19 /* Pods-OSXDemo-ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 134BEB56A5F2B5C8F3FE83294F7AAF00 /* Pods-OSXDemo-ReactiveCocoa-dummy.m */; };
+		29ABECD0C0238A5D6A2EE7700785F487 /* UISegmentedControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E86673B7AB97878628F760C330A46F4 /* UISegmentedControl+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A55E0E41912005FFC148F9D0EC16B50 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 139AEEC6E450D1764DEE395F1D4C2150 /* RACSignalSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2AC330ED36C83AECCC854B30EC2AF2D5 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = E23C108CFAD47EF27DDF7E44E4FB8FB4 /* RACArraySequence.m */; };
+		2B197E526801BBA4134DF0442B4BCFF3 /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD3BE967CA3B8E13D6AECF19FB715BC /* RACBlockTrampoline.m */; };
+		2B24E6F865D0C6F6815787F1EB37DA90 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 45A10DA99BDBDB3EE7671A2C144E976D /* RACCompoundDisposable.m */; };
+		2B76C1709D705CFD4F9C1D5BB68412EC /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F527135FA232D5728A653C94B197011C /* RACReturnSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C7EC603386DEF13A0320ADEE52A0392 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F542C0B6F81A99C228AE9560FD9F0F7 /* RACEagerSequence.m */; };
+		2D60A33E08E8B99C6B66F844D2B47D5E /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 83B887511BF2617ECE7C6484B30CE242 /* NSUserDefaults+RACSupport.m */; };
+		2DBC70A5144157CA7F11350C2F9E1976 /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E3FC49C4EAA62B3E70C4F598AD6CFB8 /* RACValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2EB11740E7C4F03544D5FB66AE969088 /* Pods-iOSDemo-ReactiveViewModel-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DD67604E8C1281015A4D4D5C6F21EAC /* Pods-iOSDemo-ReactiveViewModel-dummy.m */; };
+		2EF7C178A086C87A3D429AE1A8311499 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E1508103414BB7E14E8984399C9BC442 /* RACChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F4C6D2061C4F739119CD253C93558BA /* RVMViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 961458246F38388E8FC56D87653532B5 /* RVMViewModel.m */; };
+		2F8CE56AA18ED5228F93D912EFC32448 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B794E2A62A1F6D18109105EFBC4D18 /* RACSubscriber.m */; };
+		2FC70E79ED9AE2E66F4AE82706ED73A7 /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CBDC8C527A7B2A185E69332AFC5DBBE /* RACKVOChannel.m */; };
+		2FDFF6217DCC4ECD94B75AAE7832C984 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1210B1DF19548400A35244EA4F146E81 /* RACSignal+Operations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		306921F8DB0F8A4F9DA21617F74AD094 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 274F15284CFB468B6CBCFD3F186474EB /* NSObject+RACSelectorSignal.m */; };
+		308046CACBC6851CFFFEA841AB58BFA9 /* Pods-iOSDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 05C76AF045F8C94DBD00386FD0010E37 /* Pods-iOSDemo-dummy.m */; };
+		31EE3AD7E1A14098B69EB9168BEEAC81 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CC39B61678940382A63A47C01EECD74E /* RACDelegateProxy.m */; };
+		32564E028AC0A0FB8EB01CEC3A719985 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 30602E100F44E87EA80F6063BD044256 /* RACTestScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325A7526BEAFB95631D3AFB218E5C8E7 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 708E969B2907B623C2627AD4BDF1490B /* NSUserDefaults+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329256B667C459ECAFF57031DB844399 /* NSControl+RACTextSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A05624F1E4BDA59E7E6EF34F30754B35 /* NSControl+RACTextSignalSupport.m */; };
+		32F83FBE599F3AF8DA452D73ECD5F9B9 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = F7481C5F920E60874D71CFA0D8E0DCC6 /* RACEmptySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		330DAF44DEE4EBE3FE1165F0EC045968 /* cs.lproj in Resources */ = {isa = PBXBuildFile; fileRef = B2EF32B1C7762238C3D78D165AA7F738 /* cs.lproj */; };
+		33379802E099034B34315EA46E02C4A7 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 4137AF19338CEFF61DC82EB4691B439A /* RACSignal+Operations.m */; };
+		33DC995BB8D22582E10630DA4006FD67 /* safari-7@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5426EAEDC82A4C05E3E03F672B22BD3 /* safari-7@2x.png */; };
+		34882A162C56E50CA1AB2E67AEEF056B /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 752BABCDFA9B041845F7EDEB8439A73D /* RACStream.m */; };
+		35F79F6CEE83CDE7A0377CEAE41F05A8 /* safari@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8E78B3714694BDAF079C4BEC728DD469 /* safari@3x.png */; };
+		3739435742EBA3C2D16A0572A1926620 /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = C1D2D16F66FD32C8B2186965C10DB8A5 /* UIBarButtonItem+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		379C7C85C71305ABDDF192A7E4A8D955 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1210B1DF19548400A35244EA4F146E81 /* RACSignal+Operations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3815C341EC806260364620B03A8F7353 /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4510C24033F59D6991A5646B7E160400 /* RACScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3924A7D1C49FED56E96BD32DA310991D /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D3FF8FDA1F05D29CBFE75B9F886B2BC /* RACScheduler+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3989443ADE0FAB49226C8EA11A3F5EC3 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 274F15284CFB468B6CBCFD3F186474EB /* NSObject+RACSelectorSignal.m */; };
+		3AFA4077781740C73D15A305E3A5DC96 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 45E7B0AD2DAFA22302B74318C762D5AC /* UIBarButtonItem+RACCommandSupport.m */; };
+		3B1B8D6FBC2AFDD8D9B157EA86838C9A /* UISegmentedControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2250CB4796604C410705A22C5DC5348C /* UISegmentedControl+RACSignalSupport.m */; };
+		3C77ED8A9F8F8C66299FC779702552FB /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB11195D5A701B6AE3AF8056DA203F9 /* RACScheduler.m */; };
+		3C8652913DF3E64CFF3EC6F93C159F0A /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C2149B8B2DEA7D2F2CAE26324D19A /* NSArray+RACSequenceAdditions.m */; };
+		3D8028AB60ABCF62BBBA8074AC20ECD1 /* fi.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 77EF4D97CD37FB38AB3FBC7D2CEAE15D /* fi.lproj */; };
+		3E72C7622BBBDA150CE66A01C071B715 /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 91777DD0DB90EF236040511559064993 /* RACmetamacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FABEB04EF7E79666FA7C46D1E58F417 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA256A6B86B8586CA6D817C9AA12774 /* RACKVOProxy.m */; };
+		4010CA5E04882AFCD104BEC8BAEB91EA /* UISwitch+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 12735A6B84F1BCC09F1656B9CBA9FEF3 /* UISwitch+RACSignalSupport.m */; };
+		419981D5FE56FA2332DBF41AA6FD749E /* UISlider+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D580D1996B863820626C5132ACF88328 /* UISlider+RACSignalSupport.m */; };
+		41D3739E1F43057EEB16BF5709C33DCE /* UIRefreshControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B26AC0B4E10A34562A337CE79FF1BB /* UIRefreshControl+RACCommandSupport.m */; };
+		42A83B107791771456B3C821BA457E57 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 139AEEC6E450D1764DEE395F1D4C2150 /* RACSignalSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		42EF0E0EB115112537E414F4D60F6ACD /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5DAF475ABE18CD88FDB8CBC1F2FA40 /* RACSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4319B6918D45E698DD2AABDBDCE7D71C /* NSControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2D246BEC588B5CC01B139007AB04DC /* NSControl+RACCommandSupport.m */; };
+		44281446CE2F8A031338C1F58600F2B3 /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F5482872801818DA8BC1667FDAB0EEF /* RACTupleSequence.m */; };
+		44CE95A22383CE28D00DC5D74069A646 /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = 80ED1CA9F210442B0DD56FFA51B2C4AA /* NSObject+RACDeallocating.m */; };
+		45C6AFA5A87086475D9BAED8FC38D7A1 /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D0DF21578ECB4026776B790EB79B0C80 /* RACKVOTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		471FE947A5D86F4862CA51037CE906BA /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 570717F38B5F03275E96B390706F0523 /* RACKVOTrampoline.m */; };
+		4724EDBE9E9B968E86F4D8DE3390CE79 /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = CE7669142BF7120C7E8A1AA719C5B424 /* RACScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		47CCCF4D8540869DCBCE42ABEBF466DA /* ARChromeActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ABFEA83E3849B39372FF0DC51F84509 /* ARChromeActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		482F25F898C40949E88BC180285A7031 /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = B8A084193A9B5ECD4417960C9C0007A9 /* RACScopedDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		48EC0CA26B0D060C1DA66E429A98A7BC /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ED587E2C894A15AA5CDECB1B2B93917 /* RACPassthroughSubscriber.m */; };
+		491E350E2CDFD0EE30242E641F7A16E2 /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BA5246E0C85D0A42C3812633DF39AA0 /* RACMulticastConnection+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4AE7FE301B03A806EE87BC8353E9459F /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A882782481897DBA10857829DAD21EC /* NSOrderedSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B330C043CE4BE16BFCC3B9FC294D63D /* UIControl+RACSignalSupportPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = FF9DB25E4A4EA0271BF05C3902A1DC60 /* UIControl+RACSignalSupportPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B45D53B31AB8A6F04941E9468A24278 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 7789BBD868C60E7E7C8FB7F6E06C2746 /* RACMulticastConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4BDE01072F06E2D612951E7AF96033AB /* ARChromeActivity-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DB72C4ACA6F2BEC8BBE0132985108B3 /* ARChromeActivity-dummy.m */; };
+		4D48694FC1B10BD121AD61277A31D566 /* UIButton+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 62CBDC615FBAF562278C0677F12925BD /* UIButton+RACCommandSupport.m */; };
+		4D5967FAF31FDE819886D79CDDD15694 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 425CFFAA98530C1BFB112FCF22298B1E /* RACErrorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D7E9A8F39F6D5DDBB8975AA68B2A8B5 /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D85CF475C2D1221735F4DF331143B05 /* NSData+RACSupport.m */; };
+		4DD088F8B27FA050794544B5EB44EF24 /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = AF9C976683A04BFFF0EF3AFF514C2CA4 /* RACTargetQueueScheduler.m */; };
+		4EBD58DAE8CC90CC6FD652A176667A1C /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = A5E45E0ADD13BBAFF71F490835754362 /* RACEXTRuntimeExtensions.m */; };
+		4EC010219039EFAACE3C2FAE260BF38A /* safari~iPad.png in Resources */ = {isa = PBXBuildFile; fileRef = E68E255E47AD78C33C220D115C592450 /* safari~iPad.png */; };
+		4F94EF88BAD65610B6CEC0F979D2C577 /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B82EECBF8A1E3B1AC819C1AFC316C7 /* RACDynamicSignal.m */; };
+		4FCD1BC0A3015951A12871F6810A0569 /* RVMViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B61AD602484929783B7B20F2DA803D39 /* RVMViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50B607DAA049C3ACF3E128925D08F2BF /* safari.png in Resources */ = {isa = PBXBuildFile; fileRef = A8EE0910F31EB2C2E3E1D1B8D3781147 /* safari.png */; };
+		5123FD7574C5A83ECE4A65D44E5B1E16 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */; };
+		52672DFA4AF82E2C8C0C75D006DAAA96 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A329D816C2F2213778D9939A93331319 /* NSArray+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5349AE77739AF8494A145AB8C436DC98 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 30602E100F44E87EA80F6063BD044256 /* RACTestScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		54C3C04EECF005EA58004BEB1196CA7F /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = AEFD11FFA22306403DAE6070F4AC59D1 /* RACKVOChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55184B6F485B0CD811419F99A3CD554F /* nl.lproj in Resources */ = {isa = PBXBuildFile; fileRef = C7A4C57571FA79FC725C3DD83AE46A2A /* nl.lproj */; };
+		556B14ED74441A7D6A06DD0CBF9C462B /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CF788A90F5E2BE503F85BAFA227B0C7 /* RACReturnSignal.m */; };
+		55FE21BE82DA423872337A780B9AF9C8 /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E3FC49C4EAA62B3E70C4F598AD6CFB8 /* RACValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565AF73D422CD48D221158FB2A89F3B5 /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D7FC064031A4553160199635EEB0D18A /* RACStringSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		577BF8386F9D8B0A83F9160B37AF806D /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C293262DB77360836562A12A306721C /* RACObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58B029FECC4588E77CB6D4FA3F2C1482 /* safari-7@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3CCF3707FAD8F53466D8F2DC5C738EE0 /* safari-7@3x.png */; };
+		5A496EB5ED04C71A817DE3A5A85980EC /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = EABEDB0AE5F32B33577D0D53825DFA19 /* RACDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A597B0036427C0A1AA8ABB0A0E5916E /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AD0BF205524EC06E486E117887EB76F /* RACGroupedSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A9A70399E907CE4EF55EBC0DB36859D /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 36DABAAB01574F6D05556E05F1C7886B /* NSString+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5ADFEB280167A08892B0A853340F511F /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 81E5065A81696C65B1CD15EE4BFB536C /* RACEXTScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AE6FEA9EA3F8286274C6B4A86B85729 /* UIAlertView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B86E5079A6E12FC0EA227278CDFBC9BC /* UIAlertView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AEBD084A2DC3CAC400466720A866EC3 /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F527135FA232D5728A653C94B197011C /* RACReturnSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B366C4AEA75077D75E6E16EFF597EA3 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = AE27EA7CAEB8311B644CB85293D916DC /* NSEnumerator+RACSequenceAdditions.m */; };
+		5C09BC98C78E31EC43F5F2236AC4B973 /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = F4784456047EB0648FEB43746056BB3C /* RACQueueScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C373EC207F0D353129CDBB9B8B291C1 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F24E40BA83A51628B3EEC30C456918 /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D5DB5DAE4F502291077D57A66D4C852 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F24E40BA83A51628B3EEC30C456918 /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60C2D21CAED6072EE22E2B992409CE3E /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D71399581762FEF04A769C8B160762B4 /* RACDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61F0F00F1402C48DDCF9FB0984941B6D /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = B9657F3E32D6D8BC4DD13373E4D008AE /* RACGroupedSignal.m */; };
+		621451D209C7889C0407B5ED59C2CCC9 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 570717F38B5F03275E96B390706F0523 /* RACKVOTrampoline.m */; };
+		6253CDD55DBD0888D4FB552DAF0AEB35 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */; };
+		626035FCF89FEFB6D97F36C47DD94FC0 /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = EAB16CEA3E3AD133D8C5B60DFFF408D5 /* RACSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62FACD6C175CA25B0EE256DB3D2213E1 /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DE3B00EE7862C7D20332E3A81671AC4E /* RACValueTransformer.m */; };
+		634B6B800E8E942FDBC677D0E953AC7D /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 709639233E1017FC9678B5D70FFA2292 /* NSObject+RACSelectorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6353F8694337CD11DAAC99DE19B0109C /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D7FC064031A4553160199635EEB0D18A /* RACStringSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6401914D77F3F0FEE8557DA2EFCD2F7F /* safari@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E19E9A73E2B8495931B5F0675B79099B /* safari@2x.png */; };
+		64507DB76C8C283F604D988FF7E08C36 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 708E969B2907B623C2627AD4BDF1490B /* NSUserDefaults+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		64D264D84A7DE9B2CB404CCCE1C15F04 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 45A10DA99BDBDB3EE7671A2C144E976D /* RACCompoundDisposable.m */; };
+		65E2B6635B4681279BCCCE506102A124 /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5DAF475ABE18CD88FDB8CBC1F2FA40 /* RACSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67058F0651F8582518598C92995941EB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */; };
+		69A5F8809D7788AE8D740648FD9EE3C2 /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = B8A084193A9B5ECD4417960C9C0007A9 /* RACScopedDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69C8DEF8CDD1B42321FEC2A162CEA409 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2080FEAFF9401C553E635EEF2BA98064 /* RACSubscriptionScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A94DA27B7C075023E501CBC8B65AECD /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EE1F11172ACC84F9F93C132409F3805 /* NSObject+RACLifting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A9529C81F3AFFFBD3C4915588D7EA73 /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F4A160440A8B2FF8B2B6B06ACF1B684 /* NSDictionary+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6AEBA39571AAC1DB29984590663B6F32 /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D539C728EE32A13C34541DA04503F9 /* RACSubscriptingAssignmentTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B27277BE87F50FC8C08FED6487C3129 /* ReactiveViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FB526BE4F9FD8AB0EBC92EB95EB9B50D /* ReactiveViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B6E7C41414CFF79E741AC825223615D /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = E555809B31EE3F0C0862DF4E78868C98 /* RACTupleSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6C401876A716A112B1345423DDA2E63D /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = C16A43675F88CBA0E243ACA36D51FB62 /* RACSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6CB85887650A93C46A3A3E79F187CEEB /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 34347072E45C1C811C272F97F0329E38 /* RACImmediateScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DD0DC71C4E71CF58B9D7A292A7438C2 /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = F503678C4EFDC52B004DCB1A0B228225 /* RACImmediateScheduler.m */; };
+		6E7DE96BC6C3523718AE4DF8EA74E82E /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = A0EDD6B1D98AC2EACE5C1E4EAFEF3835 /* RACSignal.m */; };
+		6FCD6B71D38096BC9205F88AF8C3DD29 /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = A2F96E2E97075D92AF666FCCA4554B75 /* NSObject+RACDeallocating.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7028321755D0B135D27616C1730BAD94 /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = A5E45E0ADD13BBAFF71F490835754362 /* RACEXTRuntimeExtensions.m */; };
+		70676542E0F231901F73850E42F9E43E /* RVMViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B61AD602484929783B7B20F2DA803D39 /* RVMViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		70B8BEBBCC6412F9189AD5F6213BD31D /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = A711C6C1895952B4A0ED343E892FE407 /* RACStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		70DA3A4BBAE30160387F5DA4EAB9F84C /* UICollectionReusableView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = BFBB516C133840F42F99C865C2B96158 /* UICollectionReusableView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7129EEACAC89145051060CB4C23799CF /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 679CF73E3F669DEF801D3B6A4A862F6F /* RACPassthroughSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7219FDEDCB4EA278510C2D8AEA95FDEC /* sv.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 290377AC0D4A8B7D3F74623524E45DB7 /* sv.lproj */; };
+		7242077BD560139759E8F5C9A1762F3B /* ru.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 6149DD13FC4F4F6B15F2F31AE1A50C61 /* ru.lproj */; };
+		72633C7DE1A92E9D73746EE786608DE9 /* no.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 5A0409F7C17631138C7619B3975A4609 /* no.lproj */; };
+		7342B976B24215E8BB5FE589DE568828 /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A834F93BC9FADB87774DBE6790BB8215 /* RACQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74311654F1A4C56D31DB5473AF8124F3 /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 788F9FFC390C35226C2E91C9BA9CED2E /* NSObject+RACDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		744860CB40ED957211E098C361530F79 /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BAECDC6199A01A2636394F6E19A7B26 /* RACCommand.m */; };
+		74B1715740039E07122DB9623C89EBF1 /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CF788A90F5E2BE503F85BAFA227B0C7 /* RACReturnSignal.m */; };
+		74B549D9A139C4C992D3AE368AA686B3 /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B534FDB920FAC79E1FA3600D98CA267B /* NSString+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7513C8D08368F57F360BE24D54F61FE6 /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EB0DCCD4C1074EC80B2BC2F21E19BDB /* NSURLConnection+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		754D0ACA8F4FD9C57B9B3DA080E162E8 /* UISlider+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E1A33D68D81A502341B21E1B186CDFF /* UISlider+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7575A151BAA30BEE3357FDA3B29BF2F9 /* UITableViewCell+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A702BC01C7723F483E2D751160905F5 /* UITableViewCell+RACSignalSupport.m */; };
+		75C057FDCAF764B9CAC29E974C67D1E3 /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 34571FAB0B24C9F9D1B040892BF6E9F9 /* RACSubject.m */; };
+		760236F48A5121CD4BA0E0078F279AF2 /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 83B887511BF2617ECE7C6484B30CE242 /* NSUserDefaults+RACSupport.m */; };
+		76C2FDA8E565D7233515977078F8AA95 /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CBDC8C527A7B2A185E69332AFC5DBBE /* RACKVOChannel.m */; };
+		7708359B41BDDBEF66E7E3D3A0398920 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = F0CFDD7C1EEFDB41E352A8E4F761D74A /* RACUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77A6997878051D462333592E477916D4 /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 34347072E45C1C811C272F97F0329E38 /* RACImmediateScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7818CEEC583B88D0A9DAC4927361066D /* UIDatePicker+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CE87DCE07C151060F4659AF2B7F574F /* UIDatePicker+RACSignalSupport.m */; };
+		78752545740C402EE509217109A83FA4 /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 70299A5BDF8CE735AF9FCD74373B9103 /* RACIndexSetSequence.m */; };
+		790F4823D5DFD9E7EB0F5F4B21D8282A /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = EB49F60CE74628B3C0C3D769AC9840E8 /* NSNotificationCenter+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		793501298714F847860A6CD498E729ED /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 37002A63E9E6E4EEB785E3B7FC711688 /* NSInvocation+RACTypeParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		797D8D599EBE11FB6D94F377B42E2637 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = F1E4266053F0334195583B8507760C83 /* NSObject+RACPropertySubscribing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A78A8C58C53F012158B79DE82457860 /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 788F9FFC390C35226C2E91C9BA9CED2E /* NSObject+RACDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A87F615316DBAA1C85E6E992EC139D3 /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = A1076E7E636454F31CDE2099B7E3EF13 /* RACErrorSignal.m */; };
+		7A92FFE72E1D9E7104AAF36F47D55AF9 /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C44B31BD9267002FDCDD568489B54CC /* NSDictionary+RACSequenceAdditions.m */; };
+		7AE335E44DE3D4054F251471987AB74D /* UITextField+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D52EABF33B4E4C1909CE50479DCB42EB /* UITextField+RACSignalSupport.m */; };
+		7AE72FD45684A8BAEEBD8B644A2B3B0B /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B82EECBF8A1E3B1AC819C1AFC316C7 /* RACDynamicSignal.m */; };
+		7AFDFF6E6D18328563E6ADB870CA7F97 /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 4E5F4509ADD430EE8F89B85534EFBCB0 /* RACCompoundDisposableProvider.d */; };
+		7B0FE3189C06D59BC1AE38E83DFD6AF0 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = DF2188EAFC7EB0F456C45A3154B00C15 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7BA41B30F730D2F9258C2D08E7572E28 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F542C0B6F81A99C228AE9560FD9F0F7 /* RACEagerSequence.m */; };
+		7C2F536116C751D8B1436C379FE6F901 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E1902C80D9EEB727A868597548E8B6 /* NSObject+RACKVOWrapper.m */; };
+		7C8E8D460C5109ECECE4A99391EFB4E6 /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 120F3874772746C6F170DFF03207E670 /* NSFileHandle+RACSupport.m */; };
+		7D9AF1A6F8EFE65515E0C09895D8F32D /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = BDEC867AA813B628004E1B2ED75269AC /* RACScopedDisposable.m */; };
+		7DACE2B34C5BAD3FC3F0F260A4B373E9 /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = 80ED1CA9F210442B0DD56FFA51B2C4AA /* NSObject+RACDeallocating.m */; };
+		7DCE5060BEE96816EDAD4D4A54EAF187 /* UITextField+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E155750D7EF7A1BB4E4293248F36310 /* UITextField+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F2D10AA5F43FF53774625D58F26F21E /* NSObject+RACAppKitBindings.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CD59E0658C4F4D324F9E9FF5B12B04E /* NSObject+RACAppKitBindings.m */; };
+		7F71B7FCDE2E4553DB2E329E6803046C /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BB1569555B56484A2A4EAC45E16C16E2 /* NSURLConnection+RACSupport.m */; };
+		7F94FB05A94E1A8BE09BE463D53A63C5 /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B534FDB920FAC79E1FA3600D98CA267B /* NSString+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7FE2E0D0E82E28DA64D5CDBAF528553E /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = EB49F60CE74628B3C0C3D769AC9840E8 /* NSNotificationCenter+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7FEC5691706596115851881DFD0B4962 /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 803DF260A9832F92820C5B289B315CBA /* RACEmptySignal.m */; };
+		80BE5C070AE147B161D48E60FAEC6B8C /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F1428F11F9628EDD1139CDE89B8C90E9 /* NSIndexSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8289E750DB5C229947DC601F198223EB /* NSObject+RACAppKitBindings.h in Headers */ = {isa = PBXBuildFile; fileRef = E25F4518F3D58F73E2CA3AA04EB74533 /* NSObject+RACAppKitBindings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84FF70A804A6CCB482FEF07647992970 /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8779A4D42A5650CB95D2EEAC137124DF /* NSNotificationCenter+RACSupport.m */; };
+		8507B15A1ACC79F84C5422C967D000FB /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EF65483CD35392071676488A9E419E5 /* RACIndexSetSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		86EE27A19598FD8515CFFB58FEAD2CF9 /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C2B3C894F2A29A96B89D88A55E7CD9 /* NSFileHandle+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87B0C7CE5676D773C655224AD10593D9 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F43ED09C69D6993AB10E5D62CB456BF /* RACCompoundDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88DF0225129E7709EC10CD85352D6D75 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 70143DCDA08FD8511BBD162A689C9586 /* NSString+RACKeyPathUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		89120C9623EACC98C2A25C0C074DAFB5 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E38002CD8A532CB3CE53B3D19C5ECBB /* RACChannel.m */; };
+		89C78591551DD57AED2B26C601DBF01D /* TUSafariActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A9634710AD8EC8474C3D2197D43156A /* TUSafariActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B0F95EA52E02D1EF08DA47D4A708561 /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EE1F11172ACC84F9F93C132409F3805 /* NSObject+RACLifting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B702390C0974DF4ACC0931B7828C928 /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D539C728EE32A13C34541DA04503F9 /* RACSubscriptingAssignmentTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8CFAA51E7C93C300C15FBB3508E81672 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E71ED0750C26510E6B897F643D5444F /* NSString+RACKeyPathUtilities.m */; };
+		8D7B2C5A28568FEB2F4E3510FD59E50A /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = B7534CE72B041952F0E25B4B9013E05B /* RACBehaviorSubject.m */; };
+		8F188AD6B3B27F411A5F2FCBB6AC5593 /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 70299A5BDF8CE735AF9FCD74373B9103 /* RACIndexSetSequence.m */; };
+		8F26318EA6559F80FC328A67C3E5EC12 /* ARChromeActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E88E47ACC6EB670DBE4C1C53ADEC7D40 /* ARChromeActivity.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8FE4E989C08FC9C66A8FE21CC9876E22 /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BCF31D7931E616FC159ADC40EC2A01FB /* NSString+RACSequenceAdditions.m */; };
+		904F64B48655AD567011A3454ED2E60E /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B8473348A056B38B0C59FE8AE7903883 /* NSSet+RACSequenceAdditions.m */; };
+		90BAB98C93795783CD735269025BB586 /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 345CF13CD8BC2C87402001DBFD7FB227 /* UIGestureRecognizer+RACSignalSupport.m */; };
+		90F95A3315D8D7274EF8306391449538 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E1508103414BB7E14E8984399C9BC442 /* RACChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		913FFC34D5D240F643B27C7E621032FF /* zh_CN.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 23FE51336E8B43D46BA5599423B335B2 /* zh_CN.lproj */; };
+		92E9B030528119A3EBC541ABA13CFD1F /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = C644D1BF24A98CB98BCE2BBDE36C2CE6 /* NSObject+RACDescription.m */; };
+		93359A8D712A3D6A4E3AD81ECF567BA6 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 023CFD62F7DB3A7BF00BDC55B7AC66F2 /* UITableViewHeaderFooterView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93A5C133890E05899FFC5E5C78991340 /* UIActionSheet+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DF6E8AB5C2E98D00731708C6C929B5 /* UIActionSheet+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9416B6D659EFC3AF96CF2C63E2FA2068 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = EA240B549245CD49151AF9293E74AB4C /* RACEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94AB962215B9005460BA0BB5B73805A4 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = F7481C5F920E60874D71CFA0D8E0DCC6 /* RACEmptySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94C9378C149478E31A752D7ED71B36BC /* en.lproj in Resources */ = {isa = PBXBuildFile; fileRef = B292322EFE57C446C12BA9709E048CA2 /* en.lproj */; };
+		97AACD6B173F224F4BE6E2E2B8CAFCA2 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = BDEC867AA813B628004E1B2ED75269AC /* RACScopedDisposable.m */; };
+		985DED2802235D2C042A761AF391A362 /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = F4784456047EB0648FEB43746056BB3C /* RACQueueScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98F05612F9E8334C7288B9B8F5AC7186 /* safari-7~iPad.png in Resources */ = {isa = PBXBuildFile; fileRef = DA8BAB431223B649FA38C48C9D599DA0 /* safari-7~iPad.png */; };
+		9990B2DC98D7A6112BD4AB4635A493EB /* de.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 97642E37E12ECB7FB2CD3316445C79D6 /* de.lproj */; };
+		9B1338AB92269C22C8F4F68BC280A752 /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB11195D5A701B6AE3AF8056DA203F9 /* RACScheduler.m */; };
+		9B857EC4FF06A02FD604B5175B2D550A /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = FE8FE679B677A7E6F7086E8A464613C1 /* RACCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C9D0ABF36F90EA40B9DA9A206EB6911 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 7789BBD868C60E7E7C8FB7F6E06C2746 /* RACMulticastConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9CF265C257EAD177580008AE60A1DCD6 /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D53C9479EF64D8F6D8E622C5B32ED70 /* RACStringSequence.m */; };
+		9D3BBD26CD2D9F1A8B364BAA7AA94D6F /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 165353D5E6DF0EC21E8045AD106CAC18 /* RACUnit.m */; };
+		9F008889BD073E4C938D402CC3FD22D4 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = E555809B31EE3F0C0862DF4E78868C98 /* RACTupleSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F192B7764A2C41C25ED137A07D2C387 /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = B9657F3E32D6D8BC4DD13373E4D008AE /* RACGroupedSignal.m */; };
+		9F4DF02EAEDA61C3F6B5B56EE2FD4040 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5ACDEF043F65F7630EF75360218E17 /* RACSubscriptingAssignmentTrampoline.m */; };
+		9F9ED259115C94CC1CACA10F318885BD /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BCF31D7931E616FC159ADC40EC2A01FB /* NSString+RACSequenceAdditions.m */; };
+		9FFBFF312E7B1BE98A717A787F5C312A /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F0044387D70A7AF1345FD32DEE471E9 /* RACEmptySignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FFFA777E18F98A20D4F1F50FDC459C7 /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EB0DCCD4C1074EC80B2BC2F21E19BDB /* NSURLConnection+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0332DE252987782135D10A0A746A32B /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E38002CD8A532CB3CE53B3D19C5ECBB /* RACChannel.m */; };
+		A13ED79FDCDDC503FA67BDACE27779AF /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EFE8403BF0117108A8BFA500FE993BB /* RACDynamicSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A14156FD061CD7E21AA265500E280396 /* es.lproj in Resources */ = {isa = PBXBuildFile; fileRef = F36584392924EC7C3582EBC3AD7EBF16 /* es.lproj */; };
+		A318D19D5B6F22A21D66FCE750F0E343 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2080FEAFF9401C553E635EEF2BA98064 /* RACSubscriptionScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A357960C0B418516D04FEE78AC8B5E50 /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = B7534CE72B041952F0E25B4B9013E05B /* RACBehaviorSubject.m */; };
+		A378EBBA23C14A80ACA1A3CAD2EE5036 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = F9DA6CAE4C66DB6CE66E9E4C6F0C0D5C /* RACSignalSequence.m */; };
+		A3AECA61E6B413E3FDE9F02F570BE99E /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB312B74AB90A72954E8E689CE204A0 /* RACMulticastConnection.m */; };
+		A4C0764D725510E97180348B00FDB687 /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 36DABAAB01574F6D05556E05F1C7886B /* NSString+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A4DE2BA462AB433D91A8DC4272BE3231 /* UIStepper+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BFA778F7CC5142102F0E624196A066B7 /* UIStepper+RACSignalSupport.m */; };
+		A54BA1E8B2BBBC88D10A0D3FCBE68CF6 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 40B467B3D444CC69E160033689A75ECB /* RACSequence.m */; };
+		A63D974B8A6C6B056B8C6B254E0C2B21 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = F7BD85416822118288CF55855BCC81E0 /* NSString+RACSupport.m */; };
+		A71FC8E1F53DCEFE7CE8DAF316E95594 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = EA240B549245CD49151AF9293E74AB4C /* RACEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A7363E4D2FFF772428A2C69FED796213 /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = A1084B01A355A228A8CFBAD5F74F07DD /* RACSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA1086BC57E88D2EA40054C5C51FAC19 /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A834F93BC9FADB87774DBE6790BB8215 /* RACQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA8740404708D8E4CD437BA5E3C7142E /* safari-7.png in Resources */ = {isa = PBXBuildFile; fileRef = F4FA110D05C65ABC7F72F63FD2C860BE /* safari-7.png */; };
+		ABC4E0EA84D34215F8B352C7915A8661 /* ja.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 814C4B768B047AAD56C86B887F508F82 /* ja.lproj */; };
+		ADB4472A646F236085FCE282E4321F92 /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 56AD67C3E2FE5FC35A973287A0969531 /* RACTargetQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEA7593FEEDAE40ADA64A5D9D0C83043 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = E23C108CFAD47EF27DDF7E44E4FB8FB4 /* RACArraySequence.m */; };
+		B1997F077B15FB68A7BD81F303DF7AB3 /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BA5246E0C85D0A42C3812633DF39AA0 /* RACMulticastConnection+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B1D81460206CDDFD614C027BB02DD76E /* UIStepper+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = FF17E77ABBD4329BCBCF902078B45C6A /* UIStepper+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1FE1165653B2F34AF35E491A18BE2FE /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = F503678C4EFDC52B004DCB1A0B228225 /* RACImmediateScheduler.m */; };
+		B2893984FA5912CCA30AB4234C2D6C45 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = C644D1BF24A98CB98BCE2BBDE36C2CE6 /* NSObject+RACDescription.m */; };
+		B2F9F3759F20C44425A2A3D79A5ADBB6 /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = A1084B01A355A228A8CFBAD5F74F07DD /* RACSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B45AD8C13C3912FB0B2FEF2FFB7DF862 /* UIButton+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 75797F9D856D0221DB1D824DA973043C /* UIButton+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B4DE5134C3FFA447A6088874D1B5324E /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FB4497EAABD11BAF2E2889717CF3B36 /* UITableViewHeaderFooterView+RACSignalSupport.m */; };
+		B5C5602D0DBD1A138212F8C299B619B9 /* Pods-OSXDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E75209E0013BEB19BBBA0C6905C6990 /* Pods-OSXDemo-dummy.m */; };
+		B6D84DF260EF5E853B39CAEBAB789B0A /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BB1569555B56484A2A4EAC45E16C16E2 /* NSURLConnection+RACSupport.m */; };
+		B78AEB64B89FCFA6FE4F5E6AE2F9A4FC /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DD55019777DFDAA80710EF4DB635ACA /* RACEmptySequence.m */; };
+		B800F2CFDDDF6FEE369E7E619A39D330 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CB8658983C2CCC96CFE328B56A69896 /* RACTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B81FF2E808C907F2593C219E7B2BCCFE /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 469B9F12809631BD28D225E7F4BA9674 /* RACReplaySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B8702EE4FD0DAAED8B1A66F423C4F97F /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F0C00101BEFE4054340A7FCC4B3BB4 /* RACQueueScheduler.m */; };
+		B8CF27DB6DABE0B713A4E19FC549DB97 /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 165353D5E6DF0EC21E8045AD106CAC18 /* RACUnit.m */; };
+		B959F0E72E0DEAA4D67A0731CEB7E58E /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4166B67985E832129EAB15E88080B505 /* RACEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B96004809CE9A3CD070099DBD1DF3324 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CB8658983C2CCC96CFE328B56A69896 /* RACTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA1D2EA78EE147EA7FC897FCF9E182D8 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 70143DCDA08FD8511BBD162A689C9586 /* NSString+RACKeyPathUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA78591CAFE4E3076468CE9B95F25C6B /* ko.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 4EB8A204E9E6FAB7B77B4E7061D0424E /* ko.lproj */; };
+		BAA7E0977ACAF4ED9B2BD360C5BF7CF1 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E1902C80D9EEB727A868597548E8B6 /* NSObject+RACKVOWrapper.m */; };
+		BBA3BAD47ED2555CAF648659FE56ED04 /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B8030026D1265BF65763707A6A9D160 /* RACSubscriber+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC5352A3D9ED2C58E484D305E6D45EA7 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F43ED09C69D6993AB10E5D62CB456BF /* RACCompoundDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BCBC0F6456C8C133E23AC2DCDEA758B7 /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 617968821460F8AC471D89413A9DF24C /* RACEagerSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD386F39215A3EACF170CAD50DA79BC3 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 87B69D4A64EACE4F90F282AE61E7C383 /* RACUnarySequence.m */; };
+		BDDA7D0507B2612911E7C7A1F33F6D2A /* UIAlertView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 09605F595D68B72B357FEDD46D9C25BD /* UIAlertView+RACSignalSupport.m */; };
+		BEFA37180F24EE64E6DF7957A12202A0 /* safari~iPad@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B2457A8D3868D57EF8E9583D5FC4A567 /* safari~iPad@2x.png */; };
+		BF6FAE6F536CCAA08E718253E29D5145 /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = A2F96E2E97075D92AF666FCCA4554B75 /* NSObject+RACDeallocating.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C13F64A9F966077BFA4A39BEAD1F05D3 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 208B63F2B8CBA2F1604B2B19B90E445B /* RACKVOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C1A5C6BCCE51D8FA2A884BCD7B07B7FC /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 803DF260A9832F92820C5B289B315CBA /* RACEmptySignal.m */; };
+		C3DEAC1AFAE6733E1B0ACB91E9EB4320 /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EFE8403BF0117108A8BFA500FE993BB /* RACDynamicSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C42D854D6610C7DA12667853AC649BD6 /* safari-7~iPad@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5A0875D187B7E0F4E836D11CDA78E4FE /* safari-7~iPad@2x.png */; };
+		C4A787E7BF2C38010226DDB234B2B61A /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = C9A2B3C1F44E5EABFDD122B88637B8A3 /* RACSubscriptionScheduler.m */; };
+		C4E10461BF72EB34D6C51806F58A8FC1 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = DF2188EAFC7EB0F456C45A3154B00C15 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C520EBE8A7F9E3DF0D64ED49C7293D71 /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 120F3874772746C6F170DFF03207E670 /* NSFileHandle+RACSupport.m */; };
+		C5DBF7D198A1F15B381CAC16F0C1DCD7 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F1428F11F9628EDD1139CDE89B8C90E9 /* NSIndexSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C69BDA5B5D9FECB6BF8F692F1F56AD43 /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 73C34C61A1F72050F3A764015E301663 /* RACBlockTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C84F9B7881F87F8421147BF15934F9C7 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = F0CFDD7C1EEFDB41E352A8E4F761D74A /* RACUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8DF016DC2B85EDD8C9BA9015D7CD78B /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EF65483CD35392071676488A9E419E5 /* RACIndexSetSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8EF7D6AC3DF55AEBD48C0EBDB4BFF6E /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 37002A63E9E6E4EEB785E3B7FC711688 /* NSInvocation+RACTypeParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C95707ED83A75AE6E877D10774CC6504 /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A42591629D201EFB7229A3E3725E0FE /* RACUnarySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9C35AAB875C93DF217029D39C6E224D /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = 47481A10CF7489BC884AA7B2BDC03B9B /* NSObject+RACLifting.m */; };
+		CA0CD244C665035CBA37EE13BC2F5FFE /* Pods-OSXDemo-ReactiveViewModel-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A698716124DA0D099D661DC12C22E55 /* Pods-OSXDemo-ReactiveViewModel-dummy.m */; };
+		CA2265A3190A6B0672E4DB47B2562EE4 /* UICollectionReusableView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = AC38A0A06F7EAD82DB96A60257AE9453 /* UICollectionReusableView+RACSignalSupport.m */; };
+		CA9D22906D8BBFA221E513334EC22CC6 /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B9DF2E8A5B92B847CBA70C6DCBA640 /* NSSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBD8B7651425DD27959B598ADA7AB6A2 /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C44B31BD9267002FDCDD568489B54CC /* NSDictionary+RACSequenceAdditions.m */; };
+		CD80277772AE774D89C88B62C8FE4C56 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5ACDEF043F65F7630EF75360218E17 /* RACSubscriptingAssignmentTrampoline.m */; };
+		CEC2DB6B8A072F82C4158C6F50F2EC20 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D35AE7E8B8140FF1B365B76FFEFE /* RACSerialDisposable.m */; };
+		CF5508084EA1772F60ADC1086D7A2B04 /* Pods-iOSDemo-ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FA8419CFF8317241C8B6B42B22AC7F2 /* Pods-iOSDemo-ReactiveCocoa-dummy.m */; };
+		D0453495577B152354EAC0F28DC7C0EC /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F0C00101BEFE4054340A7FCC4B3BB4 /* RACQueueScheduler.m */; };
+		D1E9B705788BCA951B51E9552A4C5E24 /* eu.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 4C1BD7294254C0E4AF6523856B9E5721 /* eu.lproj */; };
+		D2685D6E4EE5EF3ABDFE5E7DD7FD3EE1 /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DE3B00EE7862C7D20332E3A81671AC4E /* RACValueTransformer.m */; };
+		D2B6748FD720AB1F6325964268E98466 /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = EABEDB0AE5F32B33577D0D53825DFA19 /* RACDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D34FDA8C926B07BC12D1BBC447F0155E /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = AE27EA7CAEB8311B644CB85293D916DC /* NSEnumerator+RACSequenceAdditions.m */; };
+		D4B352FDEC810D648AFE18FC8CEFE622 /* UIImagePickerController+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B31486C033A0039473C5310468ACDA47 /* UIImagePickerController+RACSignalSupport.m */; };
+		D517916C7433972084CA9BBC356D151A /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 98FA579B637755D52A4505EE262FDE9C /* RACArraySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D553980DF172ACADB0A507B15CA17550 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 4137AF19338CEFF61DC82EB4691B439A /* RACSignal+Operations.m */; };
+		D60023D8FA38BBAD91E7A9CDBBE34DC7 /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1E0A18E952AEC126E60CEA89612836 /* NSObject+RACKVOWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D60DA7B68B821CDA2FBA1BFA05C15959 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = F7BD85416822118288CF55855BCC81E0 /* NSString+RACSupport.m */; };
+		D6947F8F0DCDE810ADDA7C944DE508A9 /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9AE86624AFC9C6FC61F9E6104120905 /* NSOrderedSet+RACSequenceAdditions.m */; };
+		D6AC6D6D1D929CEA0D965C2917DAA233 /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 47FEDFB3D989A901B9E35C29DA7460AB /* RACSerialDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6E0AAC059597717DFDFB1802E666263 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 893F8430F08B52DC3C96E556770EDA86 /* RACDynamicSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6F7A62FE4F0FDB5A9127E35A84FABB4 /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A52E0AF777D3E19A75BE97CDC841BA /* RACStream+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D701F444A0E18344179161E3B63C11BE /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D71399581762FEF04A769C8B160762B4 /* RACDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D976B67819D93E99E514EBBCB46727B8 /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ED587E2C894A15AA5CDECB1B2B93917 /* RACPassthroughSubscriber.m */; };
+		DA41323E9B1A7FE8028C3B50254D53E7 /* UIGestureRecognizer+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2247755278162C2D9FEDE052ABF2E841 /* UIGestureRecognizer+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAACCA291A89F6C1EA9E149BDFADBBF3 /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = CE7669142BF7120C7E8A1AA719C5B424 /* RACScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB16A37E586A62A7E5B8218DE641293D /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D53C9479EF64D8F6D8E622C5B32ED70 /* RACStringSequence.m */; };
+		DB8D956A4A11007BB62DD4FC219D9CA1 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA256A6B86B8586CA6D817C9AA12774 /* RACKVOProxy.m */; };
+		DCC1F02315FC4B40B0AD825052922889 /* TUSafariActivity-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D95F780B39ACB720E40BA9DFC8A8B3D /* TUSafariActivity-dummy.m */; };
+		DD199BF2916E4F7F43CEED36A90DD7A9 /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C2B3C894F2A29A96B89D88A55E7CD9 /* NSFileHandle+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1C28B7F6569BC4156760872BF73EAE /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = 47481A10CF7489BC884AA7B2BDC03B9B /* NSObject+RACLifting.m */; };
+		DF5FDCC7614A1278EB9CAF0CDE01E16F /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4959D6C84F130BAA503DC4E91BCC82AE /* NSIndexSet+RACSequenceAdditions.m */; };
+		DFC0A6EDD126A398E4EFD1064C845A3E /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F6254C71C0A178F4171511AEB8A9687 /* NSEnumerator+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E01B6FC0037A6BF0CDAE1BA4788E35D8 /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 91777DD0DB90EF236040511559064993 /* RACmetamacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E085123F7F5F292516CE819C145E8F5A /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 4E5F4509ADD430EE8F89B85534EFBCB0 /* RACCompoundDisposableProvider.d */; };
+		E137F6DC42841C34844E4DA9B6853EA5 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = C16A43675F88CBA0E243ACA36D51FB62 /* RACSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1852C39D215715878B14DB3DD3BE95F /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F138F237430279CE7919A3BDD76B19 /* RACReplaySubject.m */; };
+		E2439E649B8F830075BE1909D2281903 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 40B467B3D444CC69E160033689A75ECB /* RACSequence.m */; };
+		E2718E832472A325B1F0B61B1F3379A0 /* sk.lproj in Resources */ = {isa = PBXBuildFile; fileRef = D3F8A4E955AF309264630F97B3AA7668 /* sk.lproj */; };
+		E2BA6AE90264F0519BF92DCB03240884 /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB312B74AB90A72954E8E689CE204A0 /* RACMulticastConnection.m */; };
+		E308177804DF49973F3E7C17B63F231C /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8779A4D42A5650CB95D2EEAC137124DF /* NSNotificationCenter+RACSupport.m */; };
+		E3FBC7F0AB128DEE4456098AA6238E30 /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = F787BB2D65C142FF059BC79EEF0F70AA /* RACEvent.m */; };
+		E42F05B433FBACA37A9FC504A4F494B6 /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D3FF8FDA1F05D29CBFE75B9F886B2BC /* RACScheduler+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E44C3CA841038E56D04787F48325D845 /* ReactiveViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FB526BE4F9FD8AB0EBC92EB95EB9B50D /* ReactiveViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E5760C05E6720421FE24362DA9406ADF /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D0DF21578ECB4026776B790EB79B0C80 /* RACKVOTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E610BCD2A45A0D5016D11B75AC84F90C /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1E0A18E952AEC126E60CEA89612836 /* NSObject+RACKVOWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E6FF15C9EAE778CDF33B23614669ECFC /* NSText+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BBAADE0D8B83A9E16996B3C1F1A0466A /* NSText+RACSignalSupport.m */; };
+		E77B1D36D14273657C02E17E20FCD927 /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B8030026D1265BF65763707A6A9D160 /* RACSubscriber+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8F2CEFD7B8D18A9FCFC07DA12CE6BD7 /* pl.lproj in Resources */ = {isa = PBXBuildFile; fileRef = DB49180EF6BE193A0E292190BCC54858 /* pl.lproj */; };
+		E8FD5158C924BC33EC819528234C4926 /* it.lproj in Resources */ = {isa = PBXBuildFile; fileRef = F2E0E11331722D7908C2B0DF7D058C0E /* it.lproj */; };
+		E930EA7AD8BEA3F35E5B0A9340F74FBB /* TUSafariActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 37204DA41C99B516A634F86B125B7502 /* TUSafariActivity.m */; };
+		E9CD006D925C33C347D435E51A5E50A0 /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F6254C71C0A178F4171511AEB8A9687 /* NSEnumerator+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA21823F8D314775E05C60990EC56E69 /* vi.lproj in Resources */ = {isa = PBXBuildFile; fileRef = FB724AB83A759E281C60DB2923ADE422 /* vi.lproj */; };
+		EAC98EB9D57F3C089B40B380EA5DDDB6 /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 772F283003A8AC5412D5438B06671B09 /* RACBehaviorSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB323D03410C15EB7B219773F631F1F3 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 893F8430F08B52DC3C96E556770EDA86 /* RACDynamicSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB387BA4DD06083739E50AA3AC8EFACD /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E500123DAEA08E61707389A7FAFC1AA /* NSData+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EBCAF61C1CDB186E0D11A80B6DF0F772 /* NSControl+RACTextSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 87ACCBB15020B3221BA89AD0523AED5D /* NSControl+RACTextSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EBF9E040CD13B87D1BB90D6B0E9C4B92 /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = AF9C976683A04BFFF0EF3AFF514C2CA4 /* RACTargetQueueScheduler.m */; };
+		EC6D4DF8E309B8C8C5FBB118CE1F090D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */; };
+		ED6E1967EBB0531F3118ABFF88C54C30 /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 97AB17BC5CF27F73DCBF21298655B330 /* RACEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE606471B0E323DC27A3FD9CDCE79C96 /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 81E5065A81696C65B1CD15EE4BFB536C /* RACEXTScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE8466A7F32F044FEBC3FB8C33A0F8C8 /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = A1076E7E636454F31CDE2099B7E3EF13 /* RACErrorSignal.m */; };
+		EF3E6833E561B3BE87E2FF525FB71EED /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = BDF5E401159ACAADA85A671D0FCE1523 /* RACDisposable.m */; };
+		EF495E545B797924F90F4A4BB57B2B42 /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BAECDC6199A01A2636394F6E19A7B26 /* RACCommand.m */; };
+		EFD198F16B31FF97259F92E70549F1F8 /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = C9A2B3C1F44E5EABFDD122B88637B8A3 /* RACSubscriptionScheduler.m */; };
+		EFDED4BFC94D6440213AE1DC01AF3F76 /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9AE86624AFC9C6FC61F9E6104120905 /* NSOrderedSet+RACSequenceAdditions.m */; };
+		F0E575B35C637764025F2288FDE558BB /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F138F237430279CE7919A3BDD76B19 /* RACReplaySubject.m */; };
+		F1A48BA97DE2ACF896DE0045A45B85BE /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B9DF2E8A5B92B847CBA70C6DCBA640 /* NSSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F22951D4303A68D7A398B2A77A4E741D /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 56AD67C3E2FE5FC35A973287A0969531 /* RACTargetQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F2ECE30114F13927C9B6F3DCD0BE60B2 /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A882782481897DBA10857829DAD21EC /* NSOrderedSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F30A2AD28FF7BDD600A944B25BE9E6EF /* UISwitch+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DAC67E544DA9537C9F6D05DDCAB9F38 /* UISwitch+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4915F8FCA94ED63E7F9A43934B7618E /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = C270D701D6F4B96200E26E366825A467 /* NSInvocation+RACTypeParsing.m */; };
+		F539E74136C991BD1394A083A9F5D979 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B794E2A62A1F6D18109105EFBC4D18 /* RACSubscriber.m */; };
+		F6E0A295659E0D25923D783A0EC98E45 /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4959D6C84F130BAA503DC4E91BCC82AE /* NSIndexSet+RACSequenceAdditions.m */; };
+		F7A5383B73EE8A88C5AFCB163B349753 /* UITableViewCell+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3104056F51F99CD36790AFB5C0C120FD /* UITableViewCell+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F816DAF284C79BB70F9898DC503DE2E9 /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = BDF5E401159ACAADA85A671D0FCE1523 /* RACDisposable.m */; };
+		F868447049EC07E3AD9CEEB1BC1763BE /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = FEB614E55CB1AE19C3A5916F1E2E356E /* RACSignalProvider.d */; };
+		F946C18662E67F5FE37970964B8AA68D /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = F9DA6CAE4C66DB6CE66E9E4C6F0C0D5C /* RACSignalSequence.m */; };
+		FA06E3C02AAD83069C5847EE253F7D43 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = F1E4266053F0334195583B8507760C83 /* NSObject+RACPropertySubscribing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FAC446E71E3DA85C1CB0D32CD012CFD0 /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C293262DB77360836562A12A306721C /* RACObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB0C00FAF8365A912CB3457382463542 /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD3BE967CA3B8E13D6AECF19FB715BC /* RACBlockTrampoline.m */; };
+		FB7FD7E4629429C23E541A6A904A4417 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE25DD04263CA735DBC0065D686C708D /* Cocoa.framework */; };
+		FC60F29575F232A0BD2F7AB41DDE3ED4 /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 772F283003A8AC5412D5438B06671B09 /* RACBehaviorSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCA630DAB92D855A2438A8773A297A9D /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D85CF475C2D1221735F4DF331143B05 /* NSData+RACSupport.m */; };
+		FE13BA25C2CB67FFB69C6CE5C0A5C555 /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = EDB801CEAA8D8921F02950E802201161 /* RACDynamicSequence.m */; };
+		FE5F69AEB71394FC9B40FC947771E7A4 /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4166B67985E832129EAB15E88080B505 /* RACEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF5658A37CAF9E6BEDA9FBB509CA7049 /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 679CF73E3F669DEF801D3B6A4A862F6F /* RACPassthroughSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF92AC25F3FD89B50CF92CAC42E25670 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = A0EDD6B1D98AC2EACE5C1E4EAFEF3835 /* RACSignal.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1DC48034B040E9F29627C06B7D6C1372 /* PBXContainerItemProxy */ = {
+		09B19A76A354E7CB0E03BC43F9178D0B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = F9609BB655C4B4B12EA7438D41309D59;
-			remoteInfo = ARChromeActivity;
-		};
-		266E57AE8F3C502CE1325CD8D1A0B73A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1CBAE1D2F2A5C12C0997DEC34CD1DA08;
-			remoteInfo = "TUSafariActivity-TUSafariActivity";
-		};
-		2BCE507CFD83FE61C719D50B98E76926 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9E3A92FD611AB2837032C6A078B63997;
-			remoteInfo = "Pods-OSXDemo-ReactiveViewModel";
-		};
-		4CD613A3706B197F08280D8905E3A51F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AB01AC1E73965EF7EE34F8FE343665F7;
-			remoteInfo = TUSafariActivity;
-		};
-		6961191592DA9073CBB9E3E4359BDBE0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FBE0B85B81D9A77E4EC5D824DFA329F2;
-			remoteInfo = "Pods-OSXDemo-ReactiveCocoa";
-		};
-		80009A738447417DF31EADE20BEBC4E2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C2D9DA1C1FD5024961E405263D6146C5;
+			remoteGlobalIDString = B673783A58522C909E63B68F082A7522;
 			remoteInfo = "Pods-iOSDemo-ReactiveCocoa";
 		};
-		811C4AF8A18AEEC4D3DE6A1299235D40 /* PBXContainerItemProxy */ = {
+		5731401371CA314765D3E4CBB923758A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FBE0B85B81D9A77E4EC5D824DFA329F2;
-			remoteInfo = "Pods-OSXDemo-ReactiveCocoa";
-		};
-		9CE570169A39FDDA54B84F03831F1283 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4C01D71208D4320C07AEB2B7EDE0AE11;
+			remoteGlobalIDString = F2CD58A8C0273CF22017094FB7192EAF;
 			remoteInfo = "Pods-iOSDemo-ReactiveViewModel";
 		};
-		AA1BF2ED2898A66A248FCC937C2E14FC /* PBXContainerItemProxy */ = {
+		7FDAB1E10B3AD5A9A03679E40FD68017 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C2D9DA1C1FD5024961E405263D6146C5;
+			remoteGlobalIDString = E718017CE7E7390CCB4CD9E0316ACBA4;
+			remoteInfo = "Pods-OSXDemo-ReactiveCocoa";
+		};
+		AA5592C351C589CF0232BA1ECE94E96F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F46241A63E3DAF75A95934F35E3D4B07;
+			remoteInfo = TUSafariActivity;
+		};
+		B56EFBB2E2BEFA4D6D88F53B8368C4C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5D7F92A58C11C2893698E38921495622;
+			remoteInfo = "Pods-OSXDemo-ReactiveViewModel";
+		};
+		C8970D126C66A7F9390B54A06097DA41 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E718017CE7E7390CCB4CD9E0316ACBA4;
+			remoteInfo = "Pods-OSXDemo-ReactiveCocoa";
+		};
+		DA53E3E84D4A25961922E644A5A47A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B673783A58522C909E63B68F082A7522;
 			remoteInfo = "Pods-iOSDemo-ReactiveCocoa";
+		};
+		EAA7D1EA3BD4A89CB1BDD02789C953E5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F7AF14DD2431C8DA79F45F4F1D22075E;
+			remoteInfo = ARChromeActivity;
+		};
+		F1D1138DAD5519B0A0251298362683B6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8991DEA8DD1EB144E05885B3DBEFF046;
+			remoteInfo = "TUSafariActivity-TUSafariActivity";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		003E242E42E67E7B590471A1B061D103 /* NSURLConnection+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLConnection+RACSupport.m"; path = "ReactiveCocoa/NSURLConnection+RACSupport.m"; sourceTree = "<group>"; };
-		005DF66FD4CD7616BE1A391EEB4B3213 /* Pods-OSXDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OSXDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
-		0167F063CC719C0E1682227664568F58 /* UIControl+RACSignalSupportPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupportPrivate.h"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.h"; sourceTree = "<group>"; };
-		01E852CFF7297852B9ACBE5B41503CA2 /* RACValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACValueTransformer.h; path = ReactiveCocoa/RACValueTransformer.h; sourceTree = "<group>"; };
-		02AB9A3D8C18D72585A9345858E3951C /* RACMulticastConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACMulticastConnection.h; path = ReactiveCocoa/RACMulticastConnection.h; sourceTree = "<group>"; };
-		03BDBC76E6B2BC3A7BA3276FD0D2F068 /* NSInvocation+RACTypeParsing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+RACTypeParsing.m"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.m"; sourceTree = "<group>"; };
-		0447E5038A8FFAE26550600D09F65E8D /* Pods-iOSDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-iOSDemo-dummy.m"; sourceTree = "<group>"; };
-		0495AA2804258AAEE06B9927011E5317 /* Pods-iOSDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-iOSDemo-acknowledgements.plist"; sourceTree = "<group>"; };
-		0514209F70FDB845FFBBB2BA42AB1B75 /* safari-7.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7.png"; path = "Pod/Assets/safari-7.png"; sourceTree = "<group>"; };
-		0567CDE373FFE56F0E721BE120EB1E95 /* RACSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubject.h; path = ReactiveCocoa/RACSubject.h; sourceTree = "<group>"; };
-		0935FDF3A822645B87AC32ACEAD9F1EB /* RACSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubject.m; path = ReactiveCocoa/RACSubject.m; sourceTree = "<group>"; };
-		09B6B1659018C794FCB6E287462BC8B2 /* NSData+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+RACSupport.m"; path = "ReactiveCocoa/NSData+RACSupport.m"; sourceTree = "<group>"; };
-		0D4340B272F3EE69DFBCFE995319DF31 /* UIControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupport.h"; path = "ReactiveCocoa/UIControl+RACSignalSupport.h"; sourceTree = "<group>"; };
-		0DC326BC82862EFA1620E6C3A7E35213 /* es.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = es.lproj; path = Pod/Assets/es.lproj; sourceTree = "<group>"; };
-		0EFF6773BDB5919C49059D46FFC988AA /* Pods-iOSDemo-ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-iOSDemo-ReactiveCocoa-dummy.m"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
-		12BEF5B1C0CABED1449FED5B593416CC /* ARChromeActivity@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@2x.png"; path = "ARChromeActivity/ARChromeActivity@2x.png"; sourceTree = "<group>"; };
-		1363FC19E200CE140654E63C0DDB6662 /* RACEagerSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = ReactiveCocoa/RACEagerSequence.m; sourceTree = "<group>"; };
-		13815EB8BFDF409CDF8521F44EBDD336 /* ARChromeActivity@2x~ipad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@2x~ipad.png"; path = "ARChromeActivity/ARChromeActivity@2x~ipad.png"; sourceTree = "<group>"; };
-		138A1DABBD9576D0FDB48C429147149D /* safari.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = safari.png; path = Pod/Assets/safari.png; sourceTree = "<group>"; };
-		142369E5E72C70E19E4EB45CE716AA80 /* sv.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = sv.lproj; path = Pod/Assets/sv.lproj; sourceTree = "<group>"; };
-		15C939B20231938145B5341121598FF1 /* UIActionSheet+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+RACSignalSupport.h"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.h"; sourceTree = "<group>"; };
-		15D14F53D043C5F0D3F9EB867E7D3FDA /* RACSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignal.m; path = ReactiveCocoa/RACSignal.m; sourceTree = "<group>"; };
-		16764EA1D4AA994848588AEE13511ABC /* NSEnumerator+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSEnumerator+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		16F9A475AFF0BFD5183F7EF312078B2E /* RACEmptySignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySignal.h; path = ReactiveCocoa/RACEmptySignal.h; sourceTree = "<group>"; };
-		17A9C9D0CFDFC9414CCB422577B05CB0 /* NSOrderedSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSOrderedSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		17DBCD15D00C9DA12A3DAE0AB7469B56 /* NSText+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSText+RACSignalSupport.m"; path = "ReactiveCocoa/NSText+RACSignalSupport.m"; sourceTree = "<group>"; };
-		188D4EA11349A675878B1C157EAC57EC /* RACDynamicSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSequence.h; path = ReactiveCocoa/RACDynamicSequence.h; sourceTree = "<group>"; };
-		18DDDDE586DBD26006146C2C58919983 /* RACEagerSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEagerSequence.h; path = ReactiveCocoa/RACEagerSequence.h; sourceTree = "<group>"; };
-		197B104667FD34E79A9F68D5DA21CE11 /* RACDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDelegateProxy.h; path = ReactiveCocoa/RACDelegateProxy.h; sourceTree = "<group>"; };
-		1B8C27EA6E4BFED387A9E1B3123825B0 /* RACImmediateScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = ReactiveCocoa/RACImmediateScheduler.m; sourceTree = "<group>"; };
-		1C35DBFCA5B591C7CE37DCBE48D1625C /* RACScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = ReactiveCocoa/RACScheduler.m; sourceTree = "<group>"; };
-		1C4C49DE77E3F848A81F428F34E79463 /* RACGroupedSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACGroupedSignal.h; path = ReactiveCocoa/RACGroupedSignal.h; sourceTree = "<group>"; };
-		1ED77FF9159C7E09FE907DB65F51B251 /* RACGroupedSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = ReactiveCocoa/RACGroupedSignal.m; sourceTree = "<group>"; };
-		1FEFE70E9171906FCD1DC5624071DEFC /* RACQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACQueueScheduler.h; path = ReactiveCocoa/RACQueueScheduler.h; sourceTree = "<group>"; };
-		20A5943D7F6A92BA8A48314327AB2516 /* eu.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = eu.lproj; path = Pod/Assets/eu.lproj; sourceTree = "<group>"; };
-		233E2535C90C8FB3CA860678CFB12392 /* libPods-iOSDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOSDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		24A8C000C2435C5362CBC8986C8B5773 /* NSNotificationCenter+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+RACSupport.h"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.h"; sourceTree = "<group>"; };
-		25D4CC1B6651C94C90A57E1DF2A80EB1 /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = ReactiveCocoa/RACStringSequence.m; sourceTree = "<group>"; };
-		2638C213F8CF918A737ABC1649BAAAD4 /* pl.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = pl.lproj; path = Pod/Assets/pl.lproj; sourceTree = "<group>"; };
-		265A63E9272E1C7B27874A0898146FA0 /* UIActionSheet+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+RACSignalSupport.m"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.m"; sourceTree = "<group>"; };
-		272BAE73358159A37442D7A772BC9C76 /* NSControl+RACTextSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSControl+RACTextSignalSupport.h"; path = "ReactiveCocoa/NSControl+RACTextSignalSupport.h"; sourceTree = "<group>"; };
-		278695DD4B5B44CDADB306E87A50D151 /* UIControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupport.m"; path = "ReactiveCocoa/UIControl+RACSignalSupport.m"; sourceTree = "<group>"; };
-		289D0DADBC9F1F6E5EE19A5D2FE7A7E9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		293C9029DA0B2225C8096D4A9AEE0949 /* RACmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACmetamacros.h; path = ReactiveCocoa/extobjc/RACmetamacros.h; sourceTree = "<group>"; };
-		2A50CB73B740D29B17FCBB116B6665E9 /* RACEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = ReactiveCocoa/RACEvent.m; sourceTree = "<group>"; };
-		2AA16D46D4D749459B908DA762C0E8D1 /* safari@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari@3x.png"; path = "Pod/Assets/safari@3x.png"; sourceTree = "<group>"; };
-		2B3A51FA14C49CBAE314B9D403F44B23 /* nl.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = nl.lproj; path = Pod/Assets/nl.lproj; sourceTree = "<group>"; };
-		2BE1D100E476FF9FDB4D86278F848CA3 /* UIBarButtonItem+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIBarButtonItem+RACCommandSupport.h"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h"; sourceTree = "<group>"; };
-		2CC01C0141A3E749870A67763348DF74 /* en.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = en.lproj; path = Pod/Assets/en.lproj; sourceTree = "<group>"; };
-		2D1044CE4AC4CE6AE373041E3567AC9F /* UISlider+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISlider+RACSignalSupport.h"; path = "ReactiveCocoa/UISlider+RACSignalSupport.h"; sourceTree = "<group>"; };
-		2DAF5A464A2AEA238D8C9013006524F0 /* ARChromeActivity-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ARChromeActivity-dummy.m"; sourceTree = "<group>"; };
-		2DC2EF9D9154E68ED17F779DA1915E8B /* UICollectionReusableView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UICollectionReusableView+RACSignalSupport.h"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		2EE58839D3A596AA8AD1E3C331D506F6 /* de.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = de.lproj; path = Pod/Assets/de.lproj; sourceTree = "<group>"; };
-		2EFC3934F752476FF141AEF6C78319B5 /* Pods-OSXDemo-ReactiveViewModel-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OSXDemo-ReactiveViewModel-prefix.pch"; sourceTree = "<group>"; };
-		2F1B9802B73E4DA17207F8CD37A39FE5 /* TUSafariActivity-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TUSafariActivity-dummy.m"; sourceTree = "<group>"; };
-		2FC799242719D2C5809E8D041BCF339E /* NSString+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSupport.m"; path = "ReactiveCocoa/NSString+RACSupport.m"; sourceTree = "<group>"; };
-		3059F2F2EBECE984FA730D95BCD35958 /* RACTupleSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTupleSequence.h; path = ReactiveCocoa/RACTupleSequence.h; sourceTree = "<group>"; };
-		317B69C1A94EF8A3DD04C4FB9AC87E33 /* vi.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = vi.lproj; path = Pod/Assets/vi.lproj; sourceTree = "<group>"; };
-		31A3BFE79097E1427A83176856BB8864 /* UITextView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextView+RACSignalSupport.m"; path = "ReactiveCocoa/UITextView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		3428AFDB0B65A20D06339592AF1D9AEB /* UIControl+RACSignalSupportPrivate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupportPrivate.m"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.m"; sourceTree = "<group>"; };
-		347410A7B054CC21BBB4EF2C83EC16B5 /* RACReturnSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = ReactiveCocoa/RACReturnSignal.m; sourceTree = "<group>"; };
-		349E1FDED193C354EB8D67439599914A /* Pods-iOSDemo-ReactiveViewModel-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-iOSDemo-ReactiveViewModel-prefix.pch"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-prefix.pch"; sourceTree = "<group>"; };
-		35B8D30589207A29D93544A443730717 /* RACMulticastConnection+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACMulticastConnection+Private.h"; path = "ReactiveCocoa/RACMulticastConnection+Private.h"; sourceTree = "<group>"; };
-		39235E7CBD2CA2BB9EA7CABEA3B918D9 /* RACMulticastConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = ReactiveCocoa/RACMulticastConnection.m; sourceTree = "<group>"; };
-		3925C05522371D1E4E40F4AE5795282E /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "MKAnnotationView+RACSignalSupport.h"; path = "ReactiveCocoa/MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		3ADBDA7231382A4A565B27790B0730BE /* NSOrderedSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSOrderedSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		3C8E5736DBD756980A7BABA839F5B636 /* RACUnarySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnarySequence.m; path = ReactiveCocoa/RACUnarySequence.m; sourceTree = "<group>"; };
-		3D400F363D8EA6A70892C39ACFE82D97 /* RACSignal+Operations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSignal+Operations.h"; path = "ReactiveCocoa/RACSignal+Operations.h"; sourceTree = "<group>"; };
-		3D44EDB64D9F57A0D754B5B5012C1BC8 /* RACUnit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnit.m; path = ReactiveCocoa/RACUnit.m; sourceTree = "<group>"; };
-		3D8A04C09132927F04FD62A4F448D441 /* Pods-OSXDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-OSXDemo-acknowledgements.plist"; sourceTree = "<group>"; };
-		3DB5C9D377823FC29EDA1D3EE02B0696 /* RACObjCRuntime.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACObjCRuntime.m; path = ReactiveCocoa/RACObjCRuntime.m; sourceTree = "<group>"; };
-		3DB823F76AF7C16F2EBC395C7D452B82 /* RACArraySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = ReactiveCocoa/RACArraySequence.m; sourceTree = "<group>"; };
-		3E73BADC9E8D63779CB79360C0F84B89 /* safari-7@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7@2x.png"; path = "Pod/Assets/safari-7@2x.png"; sourceTree = "<group>"; };
-		3ED934E6B939034E1577D7B0A469707D /* UITableViewHeaderFooterView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewHeaderFooterView+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		3EFA06C193D892B97CAAC623D521393E /* RACQueueScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACQueueScheduler+Subclass.h"; path = "ReactiveCocoa/RACQueueScheduler+Subclass.h"; sourceTree = "<group>"; };
-		3F0D14CA1ACB0C7076B3F06E55591CBB /* Pods-iOSDemo-ReactiveViewModel.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSDemo-ReactiveViewModel.xcconfig"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel.xcconfig"; sourceTree = "<group>"; };
-		3F99F0A6FFDB81788747F8A3171C270A /* RACSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriber.h; path = ReactiveCocoa/RACSubscriber.h; sourceTree = "<group>"; };
-		40E5E0E6357BD0D0AC1C2C13C550346B /* UIImagePickerController+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImagePickerController+RACSignalSupport.h"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.h"; sourceTree = "<group>"; };
-		4257FEA86FA90F2B77C7278E29858092 /* RACEmptySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySequence.h; path = ReactiveCocoa/RACEmptySequence.h; sourceTree = "<group>"; };
-		4324ABDECD6CDE80EE4D42B3ED108293 /* RACChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACChannel.h; path = ReactiveCocoa/RACChannel.h; sourceTree = "<group>"; };
-		44CA503643A7653AC1AEA112A4323D9D /* UIStepper+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIStepper+RACSignalSupport.m"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.m"; sourceTree = "<group>"; };
-		46AC114C2E3CBA44EB74C95EC0C59360 /* RACStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStream.h; path = ReactiveCocoa/RACStream.h; sourceTree = "<group>"; };
-		477DFED5355D2A19F8C1D874513C0734 /* TUSafariActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TUSafariActivity.m; path = Pod/Classes/TUSafariActivity.m; sourceTree = "<group>"; };
-		47EB64784FAA248265A307B57F9FCF39 /* ARChromeActivity.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ARChromeActivity.xcconfig; sourceTree = "<group>"; };
-		4925BE2DEE3CF6BC8B4B368134717AD6 /* Pods-iOSDemo-ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSDemo-ReactiveCocoa.xcconfig"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa.xcconfig"; sourceTree = "<group>"; };
-		49492D834246297A7CF98C30CEA2A556 /* sk.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = sk.lproj; path = Pod/Assets/sk.lproj; sourceTree = "<group>"; };
-		4B934C307FBF0D1F27BFFAAAB37ED96E /* NSURLConnection+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+RACSupport.h"; path = "ReactiveCocoa/NSURLConnection+RACSupport.h"; sourceTree = "<group>"; };
-		4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		4DE386ED3892B3192E2AA1E3E04029B5 /* RACScopedDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = ReactiveCocoa/RACScopedDisposable.m; sourceTree = "<group>"; };
-		4DF2EF1B391D591BAF3AED68B9C6CD4A /* RVMViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RVMViewModel.h; path = ReactiveViewModel/RVMViewModel.h; sourceTree = "<group>"; };
-		5180C63571ACBAA2A7DB11B1A290A09A /* RACTupleSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = ReactiveCocoa/RACTupleSequence.m; sourceTree = "<group>"; };
-		5189B2031A207A8FA6CD5C0A66929D64 /* RACArraySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACArraySequence.h; path = ReactiveCocoa/RACArraySequence.h; sourceTree = "<group>"; };
-		52FFAEBE948518482803379C80F8A38D /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+RACCommandSupport.m"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
-		53E2B0BCDB0E396BF7DDA641486794BB /* pt.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = pt.lproj; path = Pod/Assets/pt.lproj; sourceTree = "<group>"; };
-		53EC49D13C8ABF07761F08B8E25C133C /* UIButton+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+RACCommandSupport.h"; path = "ReactiveCocoa/UIButton+RACCommandSupport.h"; sourceTree = "<group>"; };
-		5489A687C2806D8DA45E37B43109B3D0 /* NSObject+RACPropertySubscribing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACPropertySubscribing.h"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.h"; sourceTree = "<group>"; };
-		54BCEF405EA3B7D1B643D1ABC8CA1C5A /* RACKVOProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOProxy.m; path = ReactiveCocoa/RACKVOProxy.m; sourceTree = "<group>"; };
-		54C2599E17B9A70EDB8547A831B50BD0 /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = "<group>"; };
-		56B0F6DD87776B594048AEAE3FF2E706 /* Pods-iOSDemo-ReactiveViewModel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-iOSDemo-ReactiveViewModel-dummy.m"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-dummy.m"; sourceTree = "<group>"; };
-		5879B8B48431419CE4AF8720DD96176A /* NSDictionary+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		59AAC6F913A5EE37789B86850AAF49FC /* RVMViewModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RVMViewModel.m; path = ReactiveViewModel/RVMViewModel.m; sourceTree = "<group>"; };
-		5A3AFFCB336D6A2A8FBE001E2BD3BB8F /* NSObject+RACSelectorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACSelectorSignal.h"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.h"; sourceTree = "<group>"; };
-		5AC54F503BAFAE36F032D4A927FDA326 /* TUSafariActivity-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "TUSafariActivity-Private.xcconfig"; sourceTree = "<group>"; };
-		5AFE052DA2259F4D29680A0F0F37B73D /* RACDynamicSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = ReactiveCocoa/RACDynamicSignal.m; sourceTree = "<group>"; };
-		5BDEE4AEB45BD91ED2AC28A8136D436A /* RACDelegateProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDelegateProxy.m; path = ReactiveCocoa/RACDelegateProxy.m; sourceTree = "<group>"; };
-		5E13A98C680E9E8010B34C6F3F8A37AF /* ARChromeActivity~ipad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity~ipad.png"; path = "ARChromeActivity/ARChromeActivity~ipad.png"; sourceTree = "<group>"; };
-		60680B2809624648BD2BE9258E14331E /* Pods-iOSDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-iOSDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
-		65EE3C5478E31D18F80192C9E019DF17 /* RACDynamicSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSignal.h; path = ReactiveCocoa/RACDynamicSignal.h; sourceTree = "<group>"; };
-		6637492CC2B364C39D40D5351D972947 /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = "<group>"; };
-		66766A6D1C81A945DAB83EFFA4EFCA16 /* safari-7~iPad@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7~iPad@2x.png"; path = "Pod/Assets/safari-7~iPad@2x.png"; sourceTree = "<group>"; };
-		66D59063E166FE928FE993BCC3BE236B /* NSObject+RACSelectorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACSelectorSignal.m"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.m"; sourceTree = "<group>"; };
-		6846730D0A4DAA2F536A7682FC11C5CF /* NSDictionary+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		69BBD58C3874DD439EBCCAC57098AE21 /* RACSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSequence.h; path = ReactiveCocoa/RACSequence.h; sourceTree = "<group>"; };
-		6B796E4AD2FB84A58C72649E4DFECBE5 /* ARChromeActivity.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = ARChromeActivity.png; path = ARChromeActivity/ARChromeActivity.png; sourceTree = "<group>"; };
-		6BFAAF0510C13BE305EDC1143245AF80 /* NSString+RACKeyPathUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACKeyPathUtilities.h"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.h"; sourceTree = "<group>"; };
-		6C99A36591AF5CB5804BAA9F521FB5E7 /* RACEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEXTRuntimeExtensions.m; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		6CC070D947F559BC5A3222915ABE78CD /* NSObject+RACKVOWrapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACKVOWrapper.h"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.h"; sourceTree = "<group>"; };
-		6D6B4CEF46ED4BEDC0BF8FD80520A060 /* RACDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = ReactiveCocoa/RACDisposable.m; sourceTree = "<group>"; };
-		6DC8652C1E7FCFDDA8BF8790D9B7F54E /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = "<group>"; };
-		6DFB677FA0CF9D2064F007BB1FB12AFF /* NSText+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSText+RACSignalSupport.h"; path = "ReactiveCocoa/NSText+RACSignalSupport.h"; sourceTree = "<group>"; };
-		6E4841A2F2258085854D3651DD1C78D3 /* NSSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		6F2FC7FE2ECDAD999DC1FF54627A29B1 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		7057D8040E6E22620A32A1A4125D991C /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptingAssignmentTrampoline.m; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
-		71542763296C6D0C0B5E0CDF83B59F20 /* Pods-OSXDemo-ReactiveCocoa-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo-ReactiveCocoa-Private.xcconfig"; sourceTree = "<group>"; };
-		72758B728D8AB6C632836340DCD900DE /* UITextField+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextField+RACSignalSupport.h"; path = "ReactiveCocoa/UITextField+RACSignalSupport.h"; sourceTree = "<group>"; };
-		7287809267EFD8915EE4B6D61DE460C3 /* NSObject+RACAppKitBindings.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACAppKitBindings.h"; path = "ReactiveCocoa/NSObject+RACAppKitBindings.h"; sourceTree = "<group>"; };
-		72E83AE4CD7EED36A7C6347CE4378C27 /* RACEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTKeyPathCoding.h; path = ReactiveCocoa/extobjc/RACEXTKeyPathCoding.h; sourceTree = "<group>"; };
-		73B3FCC97278A75478097B6CC0768F90 /* NSFileHandle+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileHandle+RACSupport.m"; path = "ReactiveCocoa/NSFileHandle+RACSupport.m"; sourceTree = "<group>"; };
-		74C6A8D1D2A7072FC25CAE38632C18EC /* NSString+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		75D7D01A90BECF813F328A2DA082DB42 /* RACDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDisposable.h; path = ReactiveCocoa/RACDisposable.h; sourceTree = "<group>"; };
-		76C7E3E32CB66CAB21651A04577BFDE2 /* RACIndexSetSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACIndexSetSequence.h; path = ReactiveCocoa/RACIndexSetSequence.h; sourceTree = "<group>"; };
-		7856AC70AFAE04D415C40B999A8567D9 /* RACErrorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACErrorSignal.m; path = ReactiveCocoa/RACErrorSignal.m; sourceTree = "<group>"; };
-		78CD3D7A3E70AB0C7A651F66C9978667 /* UITextField+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextField+RACSignalSupport.m"; path = "ReactiveCocoa/UITextField+RACSignalSupport.m"; sourceTree = "<group>"; };
-		78E363F84E058AE357AA0EDAA2EEB566 /* TUSafariActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TUSafariActivity.h; path = Pod/Classes/TUSafariActivity.h; sourceTree = "<group>"; };
-		78FCACA8F1F7541CADB0D6EE2AA02C57 /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = ReactiveCocoa/RACImmediateScheduler.h; sourceTree = "<group>"; };
-		7961AEC15563146002A5BF0D6DF6115F /* RACKVOProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOProxy.h; path = ReactiveCocoa/RACKVOProxy.h; sourceTree = "<group>"; };
-		7AEFE7B6B45C74503DEA67CBE7139D37 /* ARChromeActivity-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ARChromeActivity-Private.xcconfig"; sourceTree = "<group>"; };
-		7C31631E8EF0A85EEB6534D32B617F0E /* RACTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = ReactiveCocoa/RACTuple.m; sourceTree = "<group>"; };
-		7DC827809B5D9224B71EFAEEE7560F7F /* RACSignal+Operations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "RACSignal+Operations.m"; path = "ReactiveCocoa/RACSignal+Operations.m"; sourceTree = "<group>"; };
-		7EADC9D8C9636E0994AB340660AF1CAF /* fr.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = fr.lproj; path = Pod/Assets/fr.lproj; sourceTree = "<group>"; };
-		802D86B053D0806CC50539EDBD274D2F /* Pods-OSXDemo-ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo-ReactiveCocoa.xcconfig"; sourceTree = "<group>"; };
-		81259BB9DD6807FF7905E6C94FC4D0C6 /* safari@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari@2x.png"; path = "Pod/Assets/safari@2x.png"; sourceTree = "<group>"; };
-		81E98B187F4F5D954A297B69765400C3 /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		81FB5BCF7A667679A3A31516968CAED2 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = "<group>"; };
-		831687FB5D10486613F3DA0B61A46C70 /* NSObject+RACDeallocating.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDeallocating.h"; path = "ReactiveCocoa/NSObject+RACDeallocating.h"; sourceTree = "<group>"; };
-		86645EB49F8FB75B21E8306B02878A72 /* safari-7~iPad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7~iPad.png"; path = "Pod/Assets/safari-7~iPad.png"; sourceTree = "<group>"; };
-		86CE32DE04525C8C4C27F140E6FBB82A /* RACSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignal.h; path = ReactiveCocoa/RACSignal.h; sourceTree = "<group>"; };
-		874CF60F31BA05D83C495EF7777C689E /* ARChromeActivity@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@3x.png"; path = "ARChromeActivity/ARChromeActivity@3x.png"; sourceTree = "<group>"; };
-		8773FB8EDA1EDABE8A2C78D2D61A16AB /* RACReplaySubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = ReactiveCocoa/RACReplaySubject.m; sourceTree = "<group>"; };
-		886D59625C86AA324B6184EF0649CA6F /* UIAlertView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+RACSignalSupport.m"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		8879B7353BAD1C287FC4ACDC3DAC37A2 /* RACDynamicSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = ReactiveCocoa/RACDynamicSequence.m; sourceTree = "<group>"; };
-		88840275991F5A2C7F87BDF4FF477026 /* UIButton+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+RACCommandSupport.m"; path = "ReactiveCocoa/UIButton+RACCommandSupport.m"; sourceTree = "<group>"; };
-		894CFD9649A3459DD133C375212142FA /* Pods-iOSDemo-ReactiveViewModel-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSDemo-ReactiveViewModel-Private.xcconfig"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-Private.xcconfig"; sourceTree = "<group>"; };
-		8971DC9D6EAB1D6AAAE39C537BC0AC23 /* no.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = no.lproj; path = Pod/Assets/no.lproj; sourceTree = "<group>"; };
-		8989322B3B83978F83AD7CB0361A34A1 /* NSSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		89B1E455857D830E6B9D0113F96F2D48 /* Pods-iOSDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-iOSDemo.release.xcconfig"; sourceTree = "<group>"; };
-		8A5DD6C875E236D9328F2AF10B590C11 /* RACUnarySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnarySequence.h; path = ReactiveCocoa/RACUnarySequence.h; sourceTree = "<group>"; };
-		8C72957053349288966C5D4BD24E84C8 /* RACPassthroughSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACPassthroughSubscriber.h; path = ReactiveCocoa/RACPassthroughSubscriber.h; sourceTree = "<group>"; };
-		8D2D0E557458973ED0022FE510725842 /* UISegmentedControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISegmentedControl+RACSignalSupport.h"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.h"; sourceTree = "<group>"; };
-		8D59F02C5B74A313E1054FDB67DAC37E /* ARChromeActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ARChromeActivity.m; path = ARChromeActivity/ARChromeActivity.m; sourceTree = "<group>"; };
-		8FA723FFA34526F62A03A19D2E204E56 /* RACStream+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACStream+Private.h"; path = "ReactiveCocoa/RACStream+Private.h"; sourceTree = "<group>"; };
-		90148881F051DCFFF1A83F567E2F0339 /* RACScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScheduler.h; path = ReactiveCocoa/RACScheduler.h; sourceTree = "<group>"; };
-		917C79F249E898193708DA61EFABDF27 /* it.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = it.lproj; path = Pod/Assets/it.lproj; sourceTree = "<group>"; };
-		9272A08E478EFC8956C985469864CCC7 /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = ReactiveCocoa/RACSerialDisposable.m; sourceTree = "<group>"; };
-		93C536457A6D4A275CAF5E8BC886DD77 /* RACBehaviorSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBehaviorSubject.m; path = ReactiveCocoa/RACBehaviorSubject.m; sourceTree = "<group>"; };
-		93EEC199A454683642D9A27AB1E9B77C /* RACBlockTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBlockTrampoline.h; path = ReactiveCocoa/RACBlockTrampoline.h; sourceTree = "<group>"; };
-		943F9021136C30FD9BC0FE238FEDCA94 /* NSIndexSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSIndexSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		949E114381CFA92E910684B8BEAB0E59 /* NSControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSControl+RACCommandSupport.h"; path = "ReactiveCocoa/NSControl+RACCommandSupport.h"; sourceTree = "<group>"; };
-		954E95BFF007FAEDFAF7EC7483E90185 /* TUSafariActivity.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TUSafariActivity.xcconfig; sourceTree = "<group>"; };
-		958D014BD521F902010219C7B9A93B0B /* RACValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACValueTransformer.m; path = ReactiveCocoa/RACValueTransformer.m; sourceTree = "<group>"; };
-		968B7628D7650F79B99757777F1F6B45 /* RACUnit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnit.h; path = ReactiveCocoa/RACUnit.h; sourceTree = "<group>"; };
-		96FC8B8E155AC9762A2AFB38667B41A0 /* NSIndexSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSIndexSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		973754C87D63265F338926EA6894018D /* UITableViewCell+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewCell+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.m"; sourceTree = "<group>"; };
-		98C10D9070B172B8B68AAF9E2AEFB805 /* ARChromeActivity@3x~ipad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@3x~ipad.png"; path = "ARChromeActivity/ARChromeActivity@3x~ipad.png"; sourceTree = "<group>"; };
-		9A7D8D3A7EEEB292506086DF3C3AA829 /* NSFileHandle+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileHandle+RACSupport.h"; path = "ReactiveCocoa/NSFileHandle+RACSupport.h"; sourceTree = "<group>"; };
-		9D3BEAC6E02413CE43B98E3A3482C2BA /* UITableViewCell+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewCell+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.h"; sourceTree = "<group>"; };
-		9D518B70F6A5858D0CB415A288D655EA /* Pods-OSXDemo-ReactiveViewModel.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo-ReactiveViewModel.xcconfig"; sourceTree = "<group>"; };
-		9E039F964524B2DCBF9C0988486E8EEB /* RACKVOTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOTrampoline.m; path = ReactiveCocoa/RACKVOTrampoline.m; sourceTree = "<group>"; };
-		9F0A2008D479294BC6FF776848C3C083 /* NSObject+RACAppKitBindings.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACAppKitBindings.m"; path = "ReactiveCocoa/NSObject+RACAppKitBindings.m"; sourceTree = "<group>"; };
-		A06A3A96FB9D289AB191978F0589B50E /* Pods-OSXDemo-ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OSXDemo-ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
-		A085138FD85799F258E9DFFDFBC4A51D /* ReactiveCocoa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveCocoa.h; path = ReactiveCocoa/ReactiveCocoa.h; sourceTree = "<group>"; };
-		A097BAAAEA31918AC85B517BD3C79DEA /* RACCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCommand.h; path = ReactiveCocoa/RACCommand.h; sourceTree = "<group>"; };
-		A190EEABE930390FB1404033B0E34352 /* RACSignalSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignalSequence.m; path = ReactiveCocoa/RACSignalSequence.m; sourceTree = "<group>"; };
-		A1983C3667246C3F359BF258961CF349 /* Pods-OSXDemo-ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OSXDemo-ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
-		A349EB05ED550FE9CE77FD2B20C35BC0 /* UISegmentedControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISegmentedControl+RACSignalSupport.m"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.m"; sourceTree = "<group>"; };
-		A35FCD5B3D1F60E5A649F79BEC781AE1 /* libPods-iOSDemo-ReactiveViewModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOSDemo-ReactiveViewModel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A56A315A07398300294330C778796CF8 /* Pods-OSXDemo-ReactiveViewModel-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo-ReactiveViewModel-Private.xcconfig"; sourceTree = "<group>"; };
-		A6ACADEDEECCBFAA57DE01838F58A4A2 /* libPods-OSXDemo-ReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSXDemo-ReactiveCocoa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A802CA6FA3D8A8488065C6B1378DB7B6 /* UISwitch+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISwitch+RACSignalSupport.m"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.m"; sourceTree = "<group>"; };
-		A8CC845AB300C07D951F6F71237265BF /* RACEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTScope.h; path = ReactiveCocoa/extobjc/RACEXTScope.h; sourceTree = "<group>"; };
-		A8D283B6FCCEFCDCD8E834B9AE70F93D /* Pods-iOSDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-iOSDemo-resources.sh"; sourceTree = "<group>"; };
-		A9A4E2B6F473FBB306154C442E6FD9AD /* RACSubscriptionScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptionScheduler.h; path = ReactiveCocoa/RACSubscriptionScheduler.h; sourceTree = "<group>"; };
-		AC122118585236D0F4DA3B10C1245C66 /* NSData+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+RACSupport.h"; path = "ReactiveCocoa/NSData+RACSupport.h"; sourceTree = "<group>"; };
-		AC72ABC92F84FC70AD5E2503BCA885B8 /* NSObject+RACDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = "<group>"; };
-		AF18C68853CE72E437DFBC85139F5431 /* RACObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACObjCRuntime.h; path = ReactiveCocoa/RACObjCRuntime.h; sourceTree = "<group>"; };
-		AFA9C4124A0E2996DBBCFE875F3C60B9 /* UIDatePicker+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIDatePicker+RACSignalSupport.h"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.h"; sourceTree = "<group>"; };
-		B0750FD4759F28C8D918027C7C238616 /* RACStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = ReactiveCocoa/RACStream.m; sourceTree = "<group>"; };
-		B0D62EAC04D62A8F469D18ADB6E602FE /* RACEmptySignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = ReactiveCocoa/RACEmptySignal.m; sourceTree = "<group>"; };
-		B0F89EAD6445D20525C6617CDCF40E18 /* RACScopedDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScopedDisposable.h; path = ReactiveCocoa/RACScopedDisposable.h; sourceTree = "<group>"; };
-		B18349B085B61E9C4B610A155E031748 /* NSNotificationCenter+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+RACSupport.m"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.m"; sourceTree = "<group>"; };
-		B1B8861A6B229F818BCE2EC17ECEA114 /* RACSignalProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = ReactiveCocoa/RACSignalProvider.d; sourceTree = "<group>"; };
-		B40B0208A1D16EA436C900B5E6834C9B /* safari~iPad@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari~iPad@2x.png"; path = "Pod/Assets/safari~iPad@2x.png"; sourceTree = "<group>"; };
-		B4781EF1C6C2425DA7FF8C11B0FE4567 /* RACSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = ReactiveCocoa/RACSubscriber.m; sourceTree = "<group>"; };
-		B4F8F5C9B68C93238892F0A78C3D6A6D /* UITableViewHeaderFooterView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewHeaderFooterView+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		B5188C621CB3ACAC070ADD31784B8F68 /* NSObject+RACDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDescription.h"; path = "ReactiveCocoa/NSObject+RACDescription.h"; sourceTree = "<group>"; };
-		B5B459CB97CF9605C48D9E36094E5CB7 /* RACEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTRuntimeExtensions.h; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		B6411D8038636F4B27F0FFFCA810C0D7 /* ARChromeActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ARChromeActivity.h; path = ARChromeActivity/ARChromeActivity.h; sourceTree = "<group>"; };
-		B82CBB7E3811E1ABDB91CC76A2CE1DF4 /* NSUserDefaults+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+RACSupport.h"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.h"; sourceTree = "<group>"; };
-		B8EED562581C016F20A615D17793A422 /* RACTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTuple.h; path = ReactiveCocoa/RACTuple.h; sourceTree = "<group>"; };
-		B9441D0CEFAB6891A4BD48BFA9A0DD90 /* NSUserDefaults+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+RACSupport.m"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.m"; sourceTree = "<group>"; };
-		B9643DB88DE3F7C350CA02DB559AF182 /* RACSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSequence.m; path = ReactiveCocoa/RACSequence.m; sourceTree = "<group>"; };
-		B9919FA09FC18EF187A3F988C6102903 /* RACTargetQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTargetQueueScheduler.h; path = ReactiveCocoa/RACTargetQueueScheduler.h; sourceTree = "<group>"; };
-		B99FD257E3984B895A80262D85173949 /* libTUSafariActivity.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTUSafariActivity.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		00F0C00101BEFE4054340A7FCC4B3BB4 /* RACQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = ReactiveCocoa/RACQueueScheduler.m; sourceTree = "<group>"; };
+		023707F4D1F3F4E8DCE0F0A8DDC4704F /* TUSafariActivity.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TUSafariActivity.xcconfig; sourceTree = "<group>"; };
+		023CFD62F7DB3A7BF00BDC55B7AC66F2 /* UITableViewHeaderFooterView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewHeaderFooterView+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		033D56448351C3C2E66F95B8CDD8AD6C /* libPods-OSXDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSXDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		05B7537A9C61D330D19940B358C327A8 /* libPods-OSXDemo-ReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSXDemo-ReactiveCocoa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		05C76AF045F8C94DBD00386FD0010E37 /* Pods-iOSDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-iOSDemo-dummy.m"; sourceTree = "<group>"; };
+		07B794E2A62A1F6D18109105EFBC4D18 /* RACSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = ReactiveCocoa/RACSubscriber.m; sourceTree = "<group>"; };
+		08B82EECBF8A1E3B1AC819C1AFC316C7 /* RACDynamicSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = ReactiveCocoa/RACDynamicSignal.m; sourceTree = "<group>"; };
+		09605F595D68B72B357FEDD46D9C25BD /* UIAlertView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+RACSignalSupport.m"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		0A405F68FB8ADD2325247C946DE6BBE2 /* Pods-OSXDemo-ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo-ReactiveCocoa.xcconfig"; sourceTree = "<group>"; };
+		0C293262DB77360836562A12A306721C /* RACObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACObjCRuntime.h; path = ReactiveCocoa/RACObjCRuntime.h; sourceTree = "<group>"; };
+		0E500123DAEA08E61707389A7FAFC1AA /* NSData+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+RACSupport.h"; path = "ReactiveCocoa/NSData+RACSupport.h"; sourceTree = "<group>"; };
+		0E86673B7AB97878628F760C330A46F4 /* UISegmentedControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISegmentedControl+RACSignalSupport.h"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.h"; sourceTree = "<group>"; };
+		0F1E0A18E952AEC126E60CEA89612836 /* NSObject+RACKVOWrapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACKVOWrapper.h"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.h"; sourceTree = "<group>"; };
+		0F5482872801818DA8BC1667FDAB0EEF /* RACTupleSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = ReactiveCocoa/RACTupleSequence.m; sourceTree = "<group>"; };
+		0F6254C71C0A178F4171511AEB8A9687 /* NSEnumerator+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSEnumerator+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		0F7B7E42281EB96C9DCC4821797E4859 /* ARChromeActivity.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = ARChromeActivity.png; path = ARChromeActivity/ARChromeActivity.png; sourceTree = "<group>"; };
+		10981694A33D1868AA69AEC7EA0403AD /* Pods-OSXDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-OSXDemo-resources.sh"; sourceTree = "<group>"; };
+		120F3874772746C6F170DFF03207E670 /* NSFileHandle+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileHandle+RACSupport.m"; path = "ReactiveCocoa/NSFileHandle+RACSupport.m"; sourceTree = "<group>"; };
+		1210B1DF19548400A35244EA4F146E81 /* RACSignal+Operations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSignal+Operations.h"; path = "ReactiveCocoa/RACSignal+Operations.h"; sourceTree = "<group>"; };
+		12735A6B84F1BCC09F1656B9CBA9FEF3 /* UISwitch+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISwitch+RACSignalSupport.m"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.m"; sourceTree = "<group>"; };
+		134BEB56A5F2B5C8F3FE83294F7AAF00 /* Pods-OSXDemo-ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OSXDemo-ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
+		139AEEC6E450D1764DEE395F1D4C2150 /* RACSignalSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignalSequence.h; path = ReactiveCocoa/RACSignalSequence.h; sourceTree = "<group>"; };
+		1564204204A9EA7E397A5928E13DDF19 /* UITextView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextView+RACSignalSupport.h"; path = "ReactiveCocoa/UITextView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		165353D5E6DF0EC21E8045AD106CAC18 /* RACUnit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnit.m; path = ReactiveCocoa/RACUnit.m; sourceTree = "<group>"; };
+		1A702BC01C7723F483E2D751160905F5 /* UITableViewCell+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewCell+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.m"; sourceTree = "<group>"; };
+		1CBDC8C527A7B2A185E69332AFC5DBBE /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = ReactiveCocoa/RACKVOChannel.m; sourceTree = "<group>"; };
+		1CE1CC2F4F712805D1D9AF43C881D944 /* Pods-OSXDemo-ReactiveViewModel.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo-ReactiveViewModel.xcconfig"; sourceTree = "<group>"; };
+		1EB0DCCD4C1074EC80B2BC2F21E19BDB /* NSURLConnection+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+RACSupport.h"; path = "ReactiveCocoa/NSURLConnection+RACSupport.h"; sourceTree = "<group>"; };
+		2080FEAFF9401C553E635EEF2BA98064 /* RACSubscriptionScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptionScheduler.h; path = ReactiveCocoa/RACSubscriptionScheduler.h; sourceTree = "<group>"; };
+		208B63F2B8CBA2F1604B2B19B90E445B /* RACKVOProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOProxy.h; path = ReactiveCocoa/RACKVOProxy.h; sourceTree = "<group>"; };
+		2247755278162C2D9FEDE052ABF2E841 /* UIGestureRecognizer+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIGestureRecognizer+RACSignalSupport.h"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h"; sourceTree = "<group>"; };
+		2250CB4796604C410705A22C5DC5348C /* UISegmentedControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISegmentedControl+RACSignalSupport.m"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.m"; sourceTree = "<group>"; };
+		235C4CF7D2AFE8FCDC571771F68A2287 /* libPods-OSXDemo-ReactiveViewModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSXDemo-ReactiveViewModel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		236BC9E5E8DB36DE30265798B9BAF73A /* Pods-iOSDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-iOSDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		23FE51336E8B43D46BA5599423B335B2 /* zh_CN.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = zh_CN.lproj; path = Pod/Assets/zh_CN.lproj; sourceTree = "<group>"; };
+		24F544DB0ACE3BB3689704BDA915E425 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MKAnnotationView+RACSignalSupport.m"; path = "ReactiveCocoa/MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		274F15284CFB468B6CBCFD3F186474EB /* NSObject+RACSelectorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACSelectorSignal.m"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.m"; sourceTree = "<group>"; };
+		28F138F237430279CE7919A3BDD76B19 /* RACReplaySubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = ReactiveCocoa/RACReplaySubject.m; sourceTree = "<group>"; };
+		290377AC0D4A8B7D3F74623524E45DB7 /* sv.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = sv.lproj; path = Pod/Assets/sv.lproj; sourceTree = "<group>"; };
+		2B8030026D1265BF65763707A6A9D160 /* RACSubscriber+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSubscriber+Private.h"; path = "ReactiveCocoa/RACSubscriber+Private.h"; sourceTree = "<group>"; };
+		2BA5246E0C85D0A42C3812633DF39AA0 /* RACMulticastConnection+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACMulticastConnection+Private.h"; path = "ReactiveCocoa/RACMulticastConnection+Private.h"; sourceTree = "<group>"; };
+		2DAC67E544DA9537C9F6D05DDCAB9F38 /* UISwitch+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISwitch+RACSignalSupport.h"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.h"; sourceTree = "<group>"; };
+		2DB72C4ACA6F2BEC8BBE0132985108B3 /* ARChromeActivity-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ARChromeActivity-dummy.m"; sourceTree = "<group>"; };
+		2E273984E705D1D0DF8EA7EDB04937F7 /* Pods-iOSDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-iOSDemo-acknowledgements.plist"; sourceTree = "<group>"; };
+		2E71ED0750C26510E6B897F643D5444F /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = "<group>"; };
+		2E75209E0013BEB19BBBA0C6905C6990 /* Pods-OSXDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OSXDemo-dummy.m"; sourceTree = "<group>"; };
+		2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		2F5DAF475ABE18CD88FDB8CBC1F2FA40 /* RACSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignal.h; path = ReactiveCocoa/RACSignal.h; sourceTree = "<group>"; };
+		2FB4497EAABD11BAF2E2889717CF3B36 /* UITableViewHeaderFooterView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewHeaderFooterView+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		30602E100F44E87EA80F6063BD044256 /* RACTestScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTestScheduler.h; path = ReactiveCocoa/RACTestScheduler.h; sourceTree = "<group>"; };
+		30E13086600B1F4EA03B6EEDB29077BE /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+RACCommandSupport.h"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
+		3104056F51F99CD36790AFB5C0C120FD /* UITableViewCell+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewCell+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.h"; sourceTree = "<group>"; };
+		34347072E45C1C811C272F97F0329E38 /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = ReactiveCocoa/RACImmediateScheduler.h; sourceTree = "<group>"; };
+		34571FAB0B24C9F9D1B040892BF6E9F9 /* RACSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubject.m; path = ReactiveCocoa/RACSubject.m; sourceTree = "<group>"; };
+		345CF13CD8BC2C87402001DBFD7FB227 /* UIGestureRecognizer+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIGestureRecognizer+RACSignalSupport.m"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m"; sourceTree = "<group>"; };
+		36270DE5D71EF8CBE60C877DA756B83D /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = "<group>"; };
+		36DABAAB01574F6D05556E05F1C7886B /* NSString+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSupport.h"; path = "ReactiveCocoa/NSString+RACSupport.h"; sourceTree = "<group>"; };
+		37002A63E9E6E4EEB785E3B7FC711688 /* NSInvocation+RACTypeParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+RACTypeParsing.h"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.h"; sourceTree = "<group>"; };
+		37204DA41C99B516A634F86B125B7502 /* TUSafariActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TUSafariActivity.m; path = Pod/Classes/TUSafariActivity.m; sourceTree = "<group>"; };
+		37E1902C80D9EEB727A868597548E8B6 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = "<group>"; };
+		38414290241A098A8827B0B39859EEB6 /* UIActionSheet+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+RACSignalSupport.m"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.m"; sourceTree = "<group>"; };
+		39E3BE57B38E6B4994C83783F83AAC26 /* TUSafariActivity.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TUSafariActivity.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A5C2149B8B2DEA7D2F2CAE26324D19A /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		3C44B31BD9267002FDCDD568489B54CC /* NSDictionary+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		3CB11195D5A701B6AE3AF8056DA203F9 /* RACScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = ReactiveCocoa/RACScheduler.m; sourceTree = "<group>"; };
+		3CCF3707FAD8F53466D8F2DC5C738EE0 /* safari-7@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7@3x.png"; path = "Pod/Assets/safari-7@3x.png"; sourceTree = "<group>"; };
+		3E155750D7EF7A1BB4E4293248F36310 /* UITextField+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextField+RACSignalSupport.h"; path = "ReactiveCocoa/UITextField+RACSignalSupport.h"; sourceTree = "<group>"; };
+		3F43ED09C69D6993AB10E5D62CB456BF /* RACCompoundDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCompoundDisposable.h; path = ReactiveCocoa/RACCompoundDisposable.h; sourceTree = "<group>"; };
+		3FA8419CFF8317241C8B6B42B22AC7F2 /* Pods-iOSDemo-ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-iOSDemo-ReactiveCocoa-dummy.m"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
+		40B467B3D444CC69E160033689A75ECB /* RACSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSequence.m; path = ReactiveCocoa/RACSequence.m; sourceTree = "<group>"; };
+		4137AF19338CEFF61DC82EB4691B439A /* RACSignal+Operations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "RACSignal+Operations.m"; path = "ReactiveCocoa/RACSignal+Operations.m"; sourceTree = "<group>"; };
+		4166B67985E832129EAB15E88080B505 /* RACEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTRuntimeExtensions.h; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		425CFFAA98530C1BFB112FCF22298B1E /* RACErrorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACErrorSignal.h; path = ReactiveCocoa/RACErrorSignal.h; sourceTree = "<group>"; };
+		43DF6E8AB5C2E98D00731708C6C929B5 /* UIActionSheet+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+RACSignalSupport.h"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.h"; sourceTree = "<group>"; };
+		4510C24033F59D6991A5646B7E160400 /* RACScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScheduler.h; path = ReactiveCocoa/RACScheduler.h; sourceTree = "<group>"; };
+		45A10DA99BDBDB3EE7671A2C144E976D /* RACCompoundDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = ReactiveCocoa/RACCompoundDisposable.m; sourceTree = "<group>"; };
+		45E7B0AD2DAFA22302B74318C762D5AC /* UIBarButtonItem+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIBarButtonItem+RACCommandSupport.m"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m"; sourceTree = "<group>"; };
+		469B9F12809631BD28D225E7F4BA9674 /* RACReplaySubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReplaySubject.h; path = ReactiveCocoa/RACReplaySubject.h; sourceTree = "<group>"; };
+		47481A10CF7489BC884AA7B2BDC03B9B /* NSObject+RACLifting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACLifting.m"; path = "ReactiveCocoa/NSObject+RACLifting.m"; sourceTree = "<group>"; };
+		47FEDFB3D989A901B9E35C29DA7460AB /* RACSerialDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSerialDisposable.h; path = ReactiveCocoa/RACSerialDisposable.h; sourceTree = "<group>"; };
+		4959D6C84F130BAA503DC4E91BCC82AE /* NSIndexSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSIndexSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		4A698716124DA0D099D661DC12C22E55 /* Pods-OSXDemo-ReactiveViewModel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OSXDemo-ReactiveViewModel-dummy.m"; sourceTree = "<group>"; };
+		4C1BD7294254C0E4AF6523856B9E5721 /* eu.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = eu.lproj; path = Pod/Assets/eu.lproj; sourceTree = "<group>"; };
+		4C2D246BEC588B5CC01B139007AB04DC /* NSControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSControl+RACCommandSupport.m"; path = "ReactiveCocoa/NSControl+RACCommandSupport.m"; sourceTree = "<group>"; };
+		4E1A33D68D81A502341B21E1B186CDFF /* UISlider+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISlider+RACSignalSupport.h"; path = "ReactiveCocoa/UISlider+RACSignalSupport.h"; sourceTree = "<group>"; };
+		4E5F4509ADD430EE8F89B85534EFBCB0 /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = "<group>"; };
+		4EB8A204E9E6FAB7B77B4E7061D0424E /* ko.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ko.lproj; path = Pod/Assets/ko.lproj; sourceTree = "<group>"; };
+		4EE1F11172ACC84F9F93C132409F3805 /* NSObject+RACLifting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACLifting.h"; path = "ReactiveCocoa/NSObject+RACLifting.h"; sourceTree = "<group>"; };
+		4F63902A4D80BF8C416E9A4F486CCD98 /* RACTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = ReactiveCocoa/RACTuple.m; sourceTree = "<group>"; };
+		51B9DF2E8A5B92B847CBA70C6DCBA640 /* NSSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		537BAC5578E5933475936BC6122B77BF /* ARChromeActivity@3x~ipad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@3x~ipad.png"; path = "ARChromeActivity/ARChromeActivity@3x~ipad.png"; sourceTree = "<group>"; };
+		54862ADDA9043F400532C3DD8D77360E /* fr.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = fr.lproj; path = Pod/Assets/fr.lproj; sourceTree = "<group>"; };
+		54ED4B2C5C52611104E3F7E352C89ACC /* Pods-OSXDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo.release.xcconfig"; sourceTree = "<group>"; };
+		56463C80746C7F6187B968577A3272BD /* Pods-OSXDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		56AD67C3E2FE5FC35A973287A0969531 /* RACTargetQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTargetQueueScheduler.h; path = ReactiveCocoa/RACTargetQueueScheduler.h; sourceTree = "<group>"; };
+		570717F38B5F03275E96B390706F0523 /* RACKVOTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOTrampoline.m; path = ReactiveCocoa/RACKVOTrampoline.m; sourceTree = "<group>"; };
+		5A0409F7C17631138C7619B3975A4609 /* no.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = no.lproj; path = Pod/Assets/no.lproj; sourceTree = "<group>"; };
+		5A0875D187B7E0F4E836D11CDA78E4FE /* safari-7~iPad@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7~iPad@2x.png"; path = "Pod/Assets/safari-7~iPad@2x.png"; sourceTree = "<group>"; };
+		5A42591629D201EFB7229A3E3725E0FE /* RACUnarySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnarySequence.h; path = ReactiveCocoa/RACUnarySequence.h; sourceTree = "<group>"; };
+		5A9634710AD8EC8474C3D2197D43156A /* TUSafariActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TUSafariActivity.h; path = Pod/Classes/TUSafariActivity.h; sourceTree = "<group>"; };
+		5BD3BE967CA3B8E13D6AECF19FB715BC /* RACBlockTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = ReactiveCocoa/RACBlockTrampoline.m; sourceTree = "<group>"; };
+		5D53C9479EF64D8F6D8E622C5B32ED70 /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = ReactiveCocoa/RACStringSequence.m; sourceTree = "<group>"; };
+		6078BEECC76E2479A1408F40A85F8EB5 /* Pods-OSXDemo-ReactiveViewModel-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OSXDemo-ReactiveViewModel-prefix.pch"; sourceTree = "<group>"; };
+		60DB0F6D74899A76896CCA8FA33FB5D1 /* ARChromeActivity@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@2x.png"; path = "ARChromeActivity/ARChromeActivity@2x.png"; sourceTree = "<group>"; };
+		6149DD13FC4F4F6B15F2F31AE1A50C61 /* ru.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ru.lproj; path = Pod/Assets/ru.lproj; sourceTree = "<group>"; };
+		617968821460F8AC471D89413A9DF24C /* RACEagerSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEagerSequence.h; path = ReactiveCocoa/RACEagerSequence.h; sourceTree = "<group>"; };
+		62CBDC615FBAF562278C0677F12925BD /* UIButton+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+RACCommandSupport.m"; path = "ReactiveCocoa/UIButton+RACCommandSupport.m"; sourceTree = "<group>"; };
+		6612E321ECD0C38A0BE40D3334F84B26 /* Pods-iOSDemo-ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-iOSDemo-ReactiveCocoa-prefix.pch"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
+		679CF73E3F669DEF801D3B6A4A862F6F /* RACPassthroughSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACPassthroughSubscriber.h; path = ReactiveCocoa/RACPassthroughSubscriber.h; sourceTree = "<group>"; };
+		6875BC26EFDB0A1C55A6A9C5ECB3C160 /* libARChromeActivity.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libARChromeActivity.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ABFEA83E3849B39372FF0DC51F84509 /* ARChromeActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ARChromeActivity.h; path = ARChromeActivity/ARChromeActivity.h; sourceTree = "<group>"; };
+		6AD0BF205524EC06E486E117887EB76F /* RACGroupedSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACGroupedSignal.h; path = ReactiveCocoa/RACGroupedSignal.h; sourceTree = "<group>"; };
+		6CDED8AE31BDD914BEB8740875B4A18C /* UITextView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextView+RACSignalSupport.m"; path = "ReactiveCocoa/UITextView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		6CE87DCE07C151060F4659AF2B7F574F /* UIDatePicker+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIDatePicker+RACSignalSupport.m"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.m"; sourceTree = "<group>"; };
+		6D3FF8FDA1F05D29CBFE75B9F886B2BC /* RACScheduler+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Private.h"; path = "ReactiveCocoa/RACScheduler+Private.h"; sourceTree = "<group>"; };
+		6E3EF5B019FA0D87FDE0A2978F087E1E /* libPods-iOSDemo-ReactiveViewModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOSDemo-ReactiveViewModel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ED587E2C894A15AA5CDECB1B2B93917 /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = "<group>"; };
+		6EFE8403BF0117108A8BFA500FE993BB /* RACDynamicSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSignal.h; path = ReactiveCocoa/RACDynamicSignal.h; sourceTree = "<group>"; };
+		6F0044387D70A7AF1345FD32DEE471E9 /* RACEmptySignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySignal.h; path = ReactiveCocoa/RACEmptySignal.h; sourceTree = "<group>"; };
+		6F4A160440A8B2FF8B2B6B06ACF1B684 /* NSDictionary+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		6F542C0B6F81A99C228AE9560FD9F0F7 /* RACEagerSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = ReactiveCocoa/RACEagerSequence.m; sourceTree = "<group>"; };
+		70143DCDA08FD8511BBD162A689C9586 /* NSString+RACKeyPathUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACKeyPathUtilities.h"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.h"; sourceTree = "<group>"; };
+		70299A5BDF8CE735AF9FCD74373B9103 /* RACIndexSetSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACIndexSetSequence.m; path = ReactiveCocoa/RACIndexSetSequence.m; sourceTree = "<group>"; };
+		708E969B2907B623C2627AD4BDF1490B /* NSUserDefaults+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+RACSupport.h"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.h"; sourceTree = "<group>"; };
+		709639233E1017FC9678B5D70FFA2292 /* NSObject+RACSelectorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACSelectorSignal.h"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.h"; sourceTree = "<group>"; };
+		72C2B3C894F2A29A96B89D88A55E7CD9 /* NSFileHandle+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileHandle+RACSupport.h"; path = "ReactiveCocoa/NSFileHandle+RACSupport.h"; sourceTree = "<group>"; };
+		73C34C61A1F72050F3A764015E301663 /* RACBlockTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBlockTrampoline.h; path = ReactiveCocoa/RACBlockTrampoline.h; sourceTree = "<group>"; };
+		752BABCDFA9B041845F7EDEB8439A73D /* RACStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = ReactiveCocoa/RACStream.m; sourceTree = "<group>"; };
+		75797F9D856D0221DB1D824DA973043C /* UIButton+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+RACCommandSupport.h"; path = "ReactiveCocoa/UIButton+RACCommandSupport.h"; sourceTree = "<group>"; };
+		772F283003A8AC5412D5438B06671B09 /* RACBehaviorSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBehaviorSubject.h; path = ReactiveCocoa/RACBehaviorSubject.h; sourceTree = "<group>"; };
+		7789BBD868C60E7E7C8FB7F6E06C2746 /* RACMulticastConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACMulticastConnection.h; path = ReactiveCocoa/RACMulticastConnection.h; sourceTree = "<group>"; };
+		77EF4D97CD37FB38AB3FBC7D2CEAE15D /* fi.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = fi.lproj; path = Pod/Assets/fi.lproj; sourceTree = "<group>"; };
+		788F9FFC390C35226C2E91C9BA9CED2E /* NSObject+RACDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDescription.h"; path = "ReactiveCocoa/NSObject+RACDescription.h"; sourceTree = "<group>"; };
+		79CF12DF9F484817859E9440531ED693 /* ARChromeActivity-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ARChromeActivity-prefix.pch"; sourceTree = "<group>"; };
+		7A882782481897DBA10857829DAD21EC /* NSOrderedSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSOrderedSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		7CB8658983C2CCC96CFE328B56A69896 /* RACTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTuple.h; path = ReactiveCocoa/RACTuple.h; sourceTree = "<group>"; };
+		7CD59E0658C4F4D324F9E9FF5B12B04E /* NSObject+RACAppKitBindings.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACAppKitBindings.m"; path = "ReactiveCocoa/NSObject+RACAppKitBindings.m"; sourceTree = "<group>"; };
+		7CF788A90F5E2BE503F85BAFA227B0C7 /* RACReturnSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = ReactiveCocoa/RACReturnSignal.m; sourceTree = "<group>"; };
+		7D85CF475C2D1221735F4DF331143B05 /* NSData+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+RACSupport.m"; path = "ReactiveCocoa/NSData+RACSupport.m"; sourceTree = "<group>"; };
+		7DD67604E8C1281015A4D4D5C6F21EAC /* Pods-iOSDemo-ReactiveViewModel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-iOSDemo-ReactiveViewModel-dummy.m"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-dummy.m"; sourceTree = "<group>"; };
+		7E3FC49C4EAA62B3E70C4F598AD6CFB8 /* RACValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACValueTransformer.h; path = ReactiveCocoa/RACValueTransformer.h; sourceTree = "<group>"; };
+		7F87D35AE7E8B8140FF1B365B76FFEFE /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = ReactiveCocoa/RACSerialDisposable.m; sourceTree = "<group>"; };
+		803DF260A9832F92820C5B289B315CBA /* RACEmptySignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = ReactiveCocoa/RACEmptySignal.m; sourceTree = "<group>"; };
+		80ED1CA9F210442B0DD56FFA51B2C4AA /* NSObject+RACDeallocating.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDeallocating.m"; path = "ReactiveCocoa/NSObject+RACDeallocating.m"; sourceTree = "<group>"; };
+		814C4B768B047AAD56C86B887F508F82 /* ja.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ja.lproj; path = Pod/Assets/ja.lproj; sourceTree = "<group>"; };
+		81E5065A81696C65B1CD15EE4BFB536C /* RACEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTScope.h; path = ReactiveCocoa/extobjc/RACEXTScope.h; sourceTree = "<group>"; };
+		83B887511BF2617ECE7C6484B30CE242 /* NSUserDefaults+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+RACSupport.m"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.m"; sourceTree = "<group>"; };
+		87292D5B34A04F71F3E30AE616CA7257 /* Pods-OSXDemo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-OSXDemo-frameworks.sh"; sourceTree = "<group>"; };
+		8779A4D42A5650CB95D2EEAC137124DF /* NSNotificationCenter+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+RACSupport.m"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.m"; sourceTree = "<group>"; };
+		87ACCBB15020B3221BA89AD0523AED5D /* NSControl+RACTextSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSControl+RACTextSignalSupport.h"; path = "ReactiveCocoa/NSControl+RACTextSignalSupport.h"; sourceTree = "<group>"; };
+		87B69D4A64EACE4F90F282AE61E7C383 /* RACUnarySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnarySequence.m; path = ReactiveCocoa/RACUnarySequence.m; sourceTree = "<group>"; };
+		893F8430F08B52DC3C96E556770EDA86 /* RACDynamicSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSequence.h; path = ReactiveCocoa/RACDynamicSequence.h; sourceTree = "<group>"; };
+		8AA256A6B86B8586CA6D817C9AA12774 /* RACKVOProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOProxy.m; path = ReactiveCocoa/RACKVOProxy.m; sourceTree = "<group>"; };
+		8BAECDC6199A01A2636394F6E19A7B26 /* RACCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = ReactiveCocoa/RACCommand.m; sourceTree = "<group>"; };
+		8D5227FA42BD8ABC205A4B2C409C968A /* Pods-OSXDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OSXDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		8DD55019777DFDAA80710EF4DB635ACA /* RACEmptySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySequence.m; path = ReactiveCocoa/RACEmptySequence.m; sourceTree = "<group>"; };
+		8E38002CD8A532CB3CE53B3D19C5ECBB /* RACChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACChannel.m; path = ReactiveCocoa/RACChannel.m; sourceTree = "<group>"; };
+		8E78B3714694BDAF079C4BEC728DD469 /* safari@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari@3x.png"; path = "Pod/Assets/safari@3x.png"; sourceTree = "<group>"; };
+		91777DD0DB90EF236040511559064993 /* RACmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACmetamacros.h; path = ReactiveCocoa/extobjc/RACmetamacros.h; sourceTree = "<group>"; };
+		95FC426913338E8A26F80294D95579E6 /* Pods-iOSDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-iOSDemo-resources.sh"; sourceTree = "<group>"; };
+		961458246F38388E8FC56D87653532B5 /* RVMViewModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RVMViewModel.m; path = ReactiveViewModel/RVMViewModel.m; sourceTree = "<group>"; };
+		967C40AB234F3FA17185F324D2037CBC /* libTUSafariActivity.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTUSafariActivity.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		97642E37E12ECB7FB2CD3316445C79D6 /* de.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = de.lproj; path = Pod/Assets/de.lproj; sourceTree = "<group>"; };
+		97AB17BC5CF27F73DCBF21298655B330 /* RACEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEvent.h; path = ReactiveCocoa/RACEvent.h; sourceTree = "<group>"; };
+		98FA579B637755D52A4505EE262FDE9C /* RACArraySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACArraySequence.h; path = ReactiveCocoa/RACArraySequence.h; sourceTree = "<group>"; };
+		9D95F780B39ACB720E40BA9DFC8A8B3D /* TUSafariActivity-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TUSafariActivity-dummy.m"; sourceTree = "<group>"; };
+		9DCAF96FE449F756C7AE83F57E520DBB /* UIDatePicker+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIDatePicker+RACSignalSupport.h"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.h"; sourceTree = "<group>"; };
+		9DFAD16541518CE86C35D592524B3145 /* Pods-iOSDemo-ReactiveViewModel-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-iOSDemo-ReactiveViewModel-prefix.pch"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-prefix.pch"; sourceTree = "<group>"; };
+		9EF65483CD35392071676488A9E419E5 /* RACIndexSetSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACIndexSetSequence.h; path = ReactiveCocoa/RACIndexSetSequence.h; sourceTree = "<group>"; };
+		A05624F1E4BDA59E7E6EF34F30754B35 /* NSControl+RACTextSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSControl+RACTextSignalSupport.m"; path = "ReactiveCocoa/NSControl+RACTextSignalSupport.m"; sourceTree = "<group>"; };
+		A0EDD6B1D98AC2EACE5C1E4EAFEF3835 /* RACSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignal.m; path = ReactiveCocoa/RACSignal.m; sourceTree = "<group>"; };
+		A1076E7E636454F31CDE2099B7E3EF13 /* RACErrorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACErrorSignal.m; path = ReactiveCocoa/RACErrorSignal.m; sourceTree = "<group>"; };
+		A1084B01A355A228A8CFBAD5F74F07DD /* RACSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubject.h; path = ReactiveCocoa/RACSubject.h; sourceTree = "<group>"; };
+		A1189943E112E96ADAD205CBC31DDB8E /* TUSafariActivity-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TUSafariActivity-prefix.pch"; sourceTree = "<group>"; };
+		A1A52E0AF777D3E19A75BE97CDC841BA /* RACStream+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACStream+Private.h"; path = "ReactiveCocoa/RACStream+Private.h"; sourceTree = "<group>"; };
+		A2F96E2E97075D92AF666FCCA4554B75 /* NSObject+RACDeallocating.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDeallocating.h"; path = "ReactiveCocoa/NSObject+RACDeallocating.h"; sourceTree = "<group>"; };
+		A320927BAAE1EA13F662AC3CC75B6EBE /* UIControl+RACSignalSupportPrivate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupportPrivate.m"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.m"; sourceTree = "<group>"; };
+		A329D816C2F2213778D9939A93331319 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		A5E45E0ADD13BBAFF71F490835754362 /* RACEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEXTRuntimeExtensions.m; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		A711C6C1895952B4A0ED343E892FE407 /* RACStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStream.h; path = ReactiveCocoa/RACStream.h; sourceTree = "<group>"; };
+		A7B26AC0B4E10A34562A337CE79FF1BB /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+RACCommandSupport.m"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
+		A834F93BC9FADB87774DBE6790BB8215 /* RACQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACQueueScheduler.h; path = ReactiveCocoa/RACQueueScheduler.h; sourceTree = "<group>"; };
+		A8B9291624E54577E8A2B92078724D9D /* Pods-iOSDemo-ReactiveViewModel.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSDemo-ReactiveViewModel.xcconfig"; path = "../Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel.xcconfig"; sourceTree = "<group>"; };
+		A8EE0910F31EB2C2E3E1D1B8D3781147 /* safari.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = safari.png; path = Pod/Assets/safari.png; sourceTree = "<group>"; };
+		A95C2AF877BDB7D5F87CE30D15799955 /* NSControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSControl+RACCommandSupport.h"; path = "ReactiveCocoa/NSControl+RACCommandSupport.h"; sourceTree = "<group>"; };
+		AC38A0A06F7EAD82DB96A60257AE9453 /* UICollectionReusableView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UICollectionReusableView+RACSignalSupport.m"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		AE27EA7CAEB8311B644CB85293D916DC /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		AEFD11FFA22306403DAE6070F4AC59D1 /* RACKVOChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOChannel.h; path = ReactiveCocoa/RACKVOChannel.h; sourceTree = "<group>"; };
+		AF9C976683A04BFFF0EF3AFF514C2CA4 /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = "<group>"; };
+		B0037FA89196A9C782176E61F86BF72A /* libPods-iOSDemo-ReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOSDemo-ReactiveCocoa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B003F595C86326A2C6B2CCDB57B63909 /* ARChromeActivity@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@3x.png"; path = "ARChromeActivity/ARChromeActivity@3x.png"; sourceTree = "<group>"; };
+		B2457A8D3868D57EF8E9583D5FC4A567 /* safari~iPad@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari~iPad@2x.png"; path = "Pod/Assets/safari~iPad@2x.png"; sourceTree = "<group>"; };
+		B292322EFE57C446C12BA9709E048CA2 /* en.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = en.lproj; path = Pod/Assets/en.lproj; sourceTree = "<group>"; };
+		B2EF32B1C7762238C3D78D165AA7F738 /* cs.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = cs.lproj; path = Pod/Assets/cs.lproj; sourceTree = "<group>"; };
+		B31486C033A0039473C5310468ACDA47 /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImagePickerController+RACSignalSupport.m"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
+		B43EF41FED773390D1BDD74A471C83A8 /* Pods-OSXDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-OSXDemo-acknowledgements.plist"; sourceTree = "<group>"; };
+		B507DBC4C240E2456A33DF9E4090574C /* libPods-iOSDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOSDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B534FDB920FAC79E1FA3600D98CA267B /* NSString+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		B61AD602484929783B7B20F2DA803D39 /* RVMViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RVMViewModel.h; path = ReactiveViewModel/RVMViewModel.h; sourceTree = "<group>"; };
+		B7534CE72B041952F0E25B4B9013E05B /* RACBehaviorSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBehaviorSubject.m; path = ReactiveCocoa/RACBehaviorSubject.m; sourceTree = "<group>"; };
+		B8473348A056B38B0C59FE8AE7903883 /* NSSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		B86E5079A6E12FC0EA227278CDFBC9BC /* UIAlertView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+RACSignalSupport.h"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		B8A084193A9B5ECD4417960C9C0007A9 /* RACScopedDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScopedDisposable.h; path = ReactiveCocoa/RACScopedDisposable.h; sourceTree = "<group>"; };
+		B9657F3E32D6D8BC4DD13373E4D008AE /* RACGroupedSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = ReactiveCocoa/RACGroupedSignal.m; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BC3F321D5887C075F31139B5975DFA72 /* UIGestureRecognizer+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIGestureRecognizer+RACSignalSupport.m"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m"; sourceTree = "<group>"; };
-		BCE24908E1DD76F05BE3BFD1156B95CD /* NSObject+RACLifting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACLifting.h"; path = "ReactiveCocoa/NSObject+RACLifting.h"; sourceTree = "<group>"; };
-		BDA197270DE813CD77C9978D2DAEF369 /* Pods-OSXDemo-ReactiveViewModel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OSXDemo-ReactiveViewModel-dummy.m"; sourceTree = "<group>"; };
-		BE307B8FD7B5CA8DEA04A1D6F7F8AFB2 /* RACTestScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTestScheduler.h; path = ReactiveCocoa/RACTestScheduler.h; sourceTree = "<group>"; };
-		BE5AB37C99FA6C028583C29D7E72545D /* Pods-OSXDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-OSXDemo-resources.sh"; sourceTree = "<group>"; };
-		BF578BF5903DF1641C7DE12DBBB71B4A /* libPods-OSXDemo-ReactiveViewModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSXDemo-ReactiveViewModel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C05A51FD36FDD375DFE9198B8B0FF259 /* RACStringSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStringSequence.h; path = ReactiveCocoa/RACStringSequence.h; sourceTree = "<group>"; };
-		C1E20C597B94D0683ECED7071C31C4A7 /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = "<group>"; };
-		C42B476B11FC0AD93DECB928A7853D62 /* RACKVOTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOTrampoline.h; path = ReactiveCocoa/RACKVOTrampoline.h; sourceTree = "<group>"; };
-		C494068064B50BA8BBF11982F37B3F12 /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = "<group>"; };
-		C6A05A695D82F88434D0A912EC031EE2 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		C6EAE038798890FDE806B30250E09DAD /* RACCompoundDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCompoundDisposable.h; path = ReactiveCocoa/RACCompoundDisposable.h; sourceTree = "<group>"; };
-		C8B4E1B576455BF39FE0A5053F83000C /* ja.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ja.lproj; path = Pod/Assets/ja.lproj; sourceTree = "<group>"; };
-		C8C498C43C287C5F801A31F393EA6D30 /* NSControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSControl+RACCommandSupport.m"; path = "ReactiveCocoa/NSControl+RACCommandSupport.m"; sourceTree = "<group>"; };
-		C8CA520F048665D31F25988E787189B9 /* RACTestScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTestScheduler.m; path = ReactiveCocoa/RACTestScheduler.m; sourceTree = "<group>"; };
-		CB9A46F76CA8D03A47DB02342073CCB7 /* RACScheduler+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Private.h"; path = "ReactiveCocoa/RACScheduler+Private.h"; sourceTree = "<group>"; };
-		CBBAA78ABC4464F0DF879FE45A3C3759 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MKAnnotationView+RACSignalSupport.m"; path = "ReactiveCocoa/MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		CC3D4A780B8A8DFCB0E30FC6C2F1A0B2 /* RACSignalSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignalSequence.h; path = ReactiveCocoa/RACSignalSequence.h; sourceTree = "<group>"; };
-		CD013F07826A449FCBB31AB11C05472C /* RACEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEvent.h; path = ReactiveCocoa/RACEvent.h; sourceTree = "<group>"; };
-		CD5382D0ACA18ABC23819294F2F32123 /* safari-7@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7@3x.png"; path = "Pod/Assets/safari-7@3x.png"; sourceTree = "<group>"; };
-		CDB021FA2483DA1E9E846A0C737FA8A6 /* RACCompoundDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = ReactiveCocoa/RACCompoundDisposable.m; sourceTree = "<group>"; };
-		CEEB6CE9BFE79CB52095223105869FD5 /* NSObject+RACDeallocating.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDeallocating.m"; path = "ReactiveCocoa/NSObject+RACDeallocating.m"; sourceTree = "<group>"; };
-		CF9CE224D370EB567CAD58850C053B1C /* RACEmptySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySequence.m; path = ReactiveCocoa/RACEmptySequence.m; sourceTree = "<group>"; };
-		D07C4A22E4B34D3CA20F749A5BB3627A /* UISlider+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISlider+RACSignalSupport.m"; path = "ReactiveCocoa/UISlider+RACSignalSupport.m"; sourceTree = "<group>"; };
-		D1941C39AED6981364FAE3C563FA9453 /* ARChromeActivity-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ARChromeActivity-prefix.pch"; sourceTree = "<group>"; };
-		D1AEECD7595E35FEBC1CFD08D1B8E5AA /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = ReactiveCocoa/RACKVOChannel.m; sourceTree = "<group>"; };
-		D2050276400F6EB01867BAD68FB2E1A0 /* NSControl+RACTextSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSControl+RACTextSignalSupport.m"; path = "ReactiveCocoa/NSControl+RACTextSignalSupport.m"; sourceTree = "<group>"; };
-		D27AD87B3E25CC9627832153765D4939 /* RACSubscriber+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSubscriber+Private.h"; path = "ReactiveCocoa/RACSubscriber+Private.h"; sourceTree = "<group>"; };
-		D2F35B878B8E6E79BED2280C1749AEBB /* safari~iPad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari~iPad.png"; path = "Pod/Assets/safari~iPad.png"; sourceTree = "<group>"; };
-		D3C2798FF9D596802406300C7E8723BA /* RACQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = ReactiveCocoa/RACQueueScheduler.m; sourceTree = "<group>"; };
-		D48ADC77497F585ADCB941D1F0B0029F /* RACBlockTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = ReactiveCocoa/RACBlockTrampoline.m; sourceTree = "<group>"; };
-		D543B10369FF781F07957B7A26041A56 /* RACBehaviorSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBehaviorSubject.h; path = ReactiveCocoa/RACBehaviorSubject.h; sourceTree = "<group>"; };
-		D7F88AEE42657D472B2992F29311B85C /* RACCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = ReactiveCocoa/RACCommand.m; sourceTree = "<group>"; };
-		D81C0467590F8EE5A3FC23E4B050F45D /* RACChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACChannel.m; path = ReactiveCocoa/RACChannel.m; sourceTree = "<group>"; };
-		DA24B7F885E15C578578B6BD2C5E7511 /* libPods-iOSDemo-ReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOSDemo-ReactiveCocoa.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DB3482F070F513F530E64649A484F827 /* UIBarButtonItem+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIBarButtonItem+RACCommandSupport.m"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m"; sourceTree = "<group>"; };
-		DD39CA030B4599162C3E822EB80CBC33 /* UIStepper+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIStepper+RACSignalSupport.h"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.h"; sourceTree = "<group>"; };
-		DD5D0F6CABD12A493055F2BE8D9FF91F /* RACIndexSetSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACIndexSetSequence.m; path = ReactiveCocoa/RACIndexSetSequence.m; sourceTree = "<group>"; };
-		DDFB2D8D994759171B928C0C62A09628 /* ReactiveViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveViewModel.h; path = ReactiveViewModel/ReactiveViewModel.h; sourceTree = "<group>"; };
-		DE451BE988A97C4BD2DF85BAA4177D9D /* NSInvocation+RACTypeParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+RACTypeParsing.h"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.h"; sourceTree = "<group>"; };
-		E098CE032BC1EAF0A0AB6A2E19EDE2D7 /* zh_CN.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = zh_CN.lproj; path = Pod/Assets/zh_CN.lproj; sourceTree = "<group>"; };
-		E1F9B1B9A7F6D58C8C3B39A6FF22D496 /* Pods-OSXDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OSXDemo-dummy.m"; sourceTree = "<group>"; };
-		E276A41B5D96BAB853B977C537E223C6 /* Pods-iOSDemo-ReactiveCocoa-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSDemo-ReactiveCocoa-Private.xcconfig"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-Private.xcconfig"; sourceTree = "<group>"; };
-		E30E4F67358DF287E33B991CD7D35C08 /* RACKVOChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOChannel.h; path = ReactiveCocoa/RACKVOChannel.h; sourceTree = "<group>"; };
-		E3B3D473D1CAF17619F31AF002814899 /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
-		E5B2EFE7FE8D884045E8A92FFF76F2A4 /* UITextView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextView+RACSignalSupport.h"; path = "ReactiveCocoa/UITextView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		E6D3799F93F2F7A590C79FCB070DE22C /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = "<group>"; };
-		E88B0ADFBF294D399B6F67BBAE3BEB27 /* NSString+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		EA79360878BC8A37BA63762482E52EE1 /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptingAssignmentTrampoline.h; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
-		EB887DB01BF844A81142373B1A75608C /* TUSafariActivity-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TUSafariActivity-prefix.pch"; sourceTree = "<group>"; };
-		ECAE97031F73CD25E5B79FF2A0A35462 /* UIGestureRecognizer+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIGestureRecognizer+RACSignalSupport.h"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h"; sourceTree = "<group>"; };
-		ED900941E1DC1ABFB5B06F715C48ECDF /* Pods-OSXDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		EE008F0470C6E65A6125B07D4D9288A8 /* UICollectionReusableView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UICollectionReusableView+RACSignalSupport.m"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		EE5C78EC2315BB1CC10727CDF3A338ED /* Pods-OSXDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSXDemo.release.xcconfig"; sourceTree = "<group>"; };
-		EEE9FB22B588D60581B7BE13A5E1F720 /* libARChromeActivity.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libARChromeActivity.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		EFE63862E8E1599ED15D1760E1765BA1 /* RACReturnSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReturnSignal.h; path = ReactiveCocoa/RACReturnSignal.h; sourceTree = "<group>"; };
-		F018065A9386572D09E5322F0115945E /* NSObject+RACLifting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACLifting.m"; path = "ReactiveCocoa/NSObject+RACLifting.m"; sourceTree = "<group>"; };
-		F04858660A0ACDD23036F70195F1F0AD /* RACSerialDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSerialDisposable.h; path = ReactiveCocoa/RACSerialDisposable.h; sourceTree = "<group>"; };
-		F077C8F8D77D4BE463481167448A3342 /* libPods-OSXDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OSXDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F19E5E21542A06A70630A9CB46E48761 /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+RACCommandSupport.h"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
-		F20FD0A8EDF787FA061448C874715155 /* UISwitch+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISwitch+RACSignalSupport.h"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.h"; sourceTree = "<group>"; };
-		F23AAEFCF552C6430E5A77A17BF89206 /* fi.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = fi.lproj; path = Pod/Assets/fi.lproj; sourceTree = "<group>"; };
-		F37E0664305307657AFE92692D44B60E /* ko.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ko.lproj; path = Pod/Assets/ko.lproj; sourceTree = "<group>"; };
-		F485BB2CCC59F7B5B1F24EE94420556C /* NSString+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSupport.h"; path = "ReactiveCocoa/NSString+RACSupport.h"; sourceTree = "<group>"; };
-		F4ACFFD726DE98F952D2715A8FE904C3 /* cs.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = cs.lproj; path = Pod/Assets/cs.lproj; sourceTree = "<group>"; };
-		F69AD0A69C7E7090F19429598DD17BB6 /* RACErrorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACErrorSignal.h; path = ReactiveCocoa/RACErrorSignal.h; sourceTree = "<group>"; };
-		F73BBFE23390E4C468B17EA660A986A8 /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImagePickerController+RACSignalSupport.m"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
-		F76D3B8FFE292C9B1D1235A38C3ABFE2 /* Pods-iOSDemo-ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-iOSDemo-ReactiveCocoa-prefix.pch"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
-		F91F93B244BE6B9E4C89AC52949C04E1 /* UIAlertView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+RACSignalSupport.h"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		F9B82514055D19AB45D98F525AD88BC1 /* TUSafariActivity.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TUSafariActivity.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		FCF7EA8B6B5063BCB47DAA1613D288FF /* UIDatePicker+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIDatePicker+RACSignalSupport.m"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.m"; sourceTree = "<group>"; };
-		FDF9280BE17056BFCBB44C11A3F7C0B3 /* RACReplaySubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReplaySubject.h; path = ReactiveCocoa/RACReplaySubject.h; sourceTree = "<group>"; };
-		FE850AFB1F3120138D61FDBE9B17A05E /* ru.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ru.lproj; path = Pod/Assets/ru.lproj; sourceTree = "<group>"; };
-		FF6D9559B18EB2D5592A1B0B4FA52A22 /* Pods-iOSDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-iOSDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		BB1569555B56484A2A4EAC45E16C16E2 /* NSURLConnection+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLConnection+RACSupport.m"; path = "ReactiveCocoa/NSURLConnection+RACSupport.m"; sourceTree = "<group>"; };
+		BBAADE0D8B83A9E16996B3C1F1A0466A /* NSText+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSText+RACSignalSupport.m"; path = "ReactiveCocoa/NSText+RACSignalSupport.m"; sourceTree = "<group>"; };
+		BCF31D7931E616FC159ADC40EC2A01FB /* NSString+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		BDEC867AA813B628004E1B2ED75269AC /* RACScopedDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = ReactiveCocoa/RACScopedDisposable.m; sourceTree = "<group>"; };
+		BDF5E401159ACAADA85A671D0FCE1523 /* RACDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = ReactiveCocoa/RACDisposable.m; sourceTree = "<group>"; };
+		BFA778F7CC5142102F0E624196A066B7 /* UIStepper+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIStepper+RACSignalSupport.m"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.m"; sourceTree = "<group>"; };
+		BFBB516C133840F42F99C865C2B96158 /* UICollectionReusableView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UICollectionReusableView+RACSignalSupport.h"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		C023BADA5CEDAA037E32E7E73B35E716 /* NSText+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSText+RACSignalSupport.h"; path = "ReactiveCocoa/NSText+RACSignalSupport.h"; sourceTree = "<group>"; };
+		C16A43675F88CBA0E243ACA36D51FB62 /* RACSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriber.h; path = ReactiveCocoa/RACSubscriber.h; sourceTree = "<group>"; };
+		C1D2D16F66FD32C8B2186965C10DB8A5 /* UIBarButtonItem+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIBarButtonItem+RACCommandSupport.h"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h"; sourceTree = "<group>"; };
+		C270D701D6F4B96200E26E366825A467 /* NSInvocation+RACTypeParsing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+RACTypeParsing.m"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.m"; sourceTree = "<group>"; };
+		C4A6ED5392E8883803FCFF5D04D5F8F0 /* Pods-iOSDemo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-iOSDemo-frameworks.sh"; sourceTree = "<group>"; };
+		C644D1BF24A98CB98BCE2BBDE36C2CE6 /* NSObject+RACDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = "<group>"; };
+		C7A4C57571FA79FC725C3DD83AE46A2A /* nl.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = nl.lproj; path = Pod/Assets/nl.lproj; sourceTree = "<group>"; };
+		C9367045BB3B2BBFCB5B7595E1F4BD08 /* UIControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupport.h"; path = "ReactiveCocoa/UIControl+RACSignalSupport.h"; sourceTree = "<group>"; };
+		C9A2B3C1F44E5EABFDD122B88637B8A3 /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = "<group>"; };
+		CC39B61678940382A63A47C01EECD74E /* RACDelegateProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDelegateProxy.m; path = ReactiveCocoa/RACDelegateProxy.m; sourceTree = "<group>"; };
+		CE7669142BF7120C7E8A1AA719C5B424 /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
+		D0B2C4966AD0CE47B90366DA75F06F87 /* Pods-OSXDemo-ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OSXDemo-ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
+		D0DF21578ECB4026776B790EB79B0C80 /* RACKVOTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOTrampoline.h; path = ReactiveCocoa/RACKVOTrampoline.h; sourceTree = "<group>"; };
+		D3F8A4E955AF309264630F97B3AA7668 /* sk.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = sk.lproj; path = Pod/Assets/sk.lproj; sourceTree = "<group>"; };
+		D52EABF33B4E4C1909CE50479DCB42EB /* UITextField+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextField+RACSignalSupport.m"; path = "ReactiveCocoa/UITextField+RACSignalSupport.m"; sourceTree = "<group>"; };
+		D5426EAEDC82A4C05E3E03F672B22BD3 /* safari-7@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7@2x.png"; path = "Pod/Assets/safari-7@2x.png"; sourceTree = "<group>"; };
+		D580D1996B863820626C5132ACF88328 /* UISlider+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISlider+RACSignalSupport.m"; path = "ReactiveCocoa/UISlider+RACSignalSupport.m"; sourceTree = "<group>"; };
+		D71399581762FEF04A769C8B160762B4 /* RACDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDelegateProxy.h; path = ReactiveCocoa/RACDelegateProxy.h; sourceTree = "<group>"; };
+		D7FC064031A4553160199635EEB0D18A /* RACStringSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStringSequence.h; path = ReactiveCocoa/RACStringSequence.h; sourceTree = "<group>"; };
+		D9AE86624AFC9C6FC61F9E6104120905 /* NSOrderedSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSOrderedSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		DA8BAB431223B649FA38C48C9D599DA0 /* safari-7~iPad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7~iPad.png"; path = "Pod/Assets/safari-7~iPad.png"; sourceTree = "<group>"; };
+		DB49180EF6BE193A0E292190BCC54858 /* pl.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = pl.lproj; path = Pod/Assets/pl.lproj; sourceTree = "<group>"; };
+		DD3A50687D01BB54B2123BCA4E847B64 /* Pods-iOSDemo-ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSDemo-ReactiveCocoa.xcconfig"; path = "../Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa.xcconfig"; sourceTree = "<group>"; };
+		DE25DD04263CA735DBC0065D686C708D /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		DE3B00EE7862C7D20332E3A81671AC4E /* RACValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACValueTransformer.m; path = ReactiveCocoa/RACValueTransformer.m; sourceTree = "<group>"; };
+		DE5ACDEF043F65F7630EF75360218E17 /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptingAssignmentTrampoline.m; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
+		DF2188EAFC7EB0F456C45A3154B00C15 /* RACObjCRuntime.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACObjCRuntime.m; path = ReactiveCocoa/RACObjCRuntime.m; sourceTree = "<group>"; };
+		E1508103414BB7E14E8984399C9BC442 /* RACChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACChannel.h; path = ReactiveCocoa/RACChannel.h; sourceTree = "<group>"; };
+		E19E9A73E2B8495931B5F0675B79099B /* safari@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari@2x.png"; path = "Pod/Assets/safari@2x.png"; sourceTree = "<group>"; };
+		E23C108CFAD47EF27DDF7E44E4FB8FB4 /* RACArraySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = ReactiveCocoa/RACArraySequence.m; sourceTree = "<group>"; };
+		E25F4518F3D58F73E2CA3AA04EB74533 /* NSObject+RACAppKitBindings.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACAppKitBindings.h"; path = "ReactiveCocoa/NSObject+RACAppKitBindings.h"; sourceTree = "<group>"; };
+		E366FD03168029DA75C718E058A8EDC8 /* ARChromeActivity.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ARChromeActivity.xcconfig; sourceTree = "<group>"; };
+		E3797EE485CA838B44F5E6FF9659A771 /* Pods-iOSDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-iOSDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		E3D1145FCAFD92D8CA5612CA6A935B5E /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "MKAnnotationView+RACSignalSupport.h"; path = "ReactiveCocoa/MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		E4D9DBFB608C04F750360D207CB52017 /* Pods-iOSDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-iOSDemo.release.xcconfig"; sourceTree = "<group>"; };
+		E555809B31EE3F0C0862DF4E78868C98 /* RACTupleSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTupleSequence.h; path = ReactiveCocoa/RACTupleSequence.h; sourceTree = "<group>"; };
+		E5BE3BA2C5DC6C49534DE219797AC9E8 /* RACTestScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTestScheduler.m; path = ReactiveCocoa/RACTestScheduler.m; sourceTree = "<group>"; };
+		E5D539C728EE32A13C34541DA04503F9 /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptingAssignmentTrampoline.h; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
+		E68E255E47AD78C33C220D115C592450 /* safari~iPad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari~iPad.png"; path = "Pod/Assets/safari~iPad.png"; sourceTree = "<group>"; };
+		E88E47ACC6EB670DBE4C1C53ADEC7D40 /* ARChromeActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ARChromeActivity.m; path = ARChromeActivity/ARChromeActivity.m; sourceTree = "<group>"; };
+		EA240B549245CD49151AF9293E74AB4C /* RACEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTKeyPathCoding.h; path = ReactiveCocoa/extobjc/RACEXTKeyPathCoding.h; sourceTree = "<group>"; };
+		EAB16CEA3E3AD133D8C5B60DFFF408D5 /* RACSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSequence.h; path = ReactiveCocoa/RACSequence.h; sourceTree = "<group>"; };
+		EABEDB0AE5F32B33577D0D53825DFA19 /* RACDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDisposable.h; path = ReactiveCocoa/RACDisposable.h; sourceTree = "<group>"; };
+		EB49F60CE74628B3C0C3D769AC9840E8 /* NSNotificationCenter+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+RACSupport.h"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.h"; sourceTree = "<group>"; };
+		EDB801CEAA8D8921F02950E802201161 /* RACDynamicSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = ReactiveCocoa/RACDynamicSequence.m; sourceTree = "<group>"; };
+		F0CFDD7C1EEFDB41E352A8E4F761D74A /* RACUnit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnit.h; path = ReactiveCocoa/RACUnit.h; sourceTree = "<group>"; };
+		F1428F11F9628EDD1139CDE89B8C90E9 /* NSIndexSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSIndexSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		F1E4266053F0334195583B8507760C83 /* NSObject+RACPropertySubscribing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACPropertySubscribing.h"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.h"; sourceTree = "<group>"; };
+		F2E0E11331722D7908C2B0DF7D058C0E /* it.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = it.lproj; path = Pod/Assets/it.lproj; sourceTree = "<group>"; };
+		F36584392924EC7C3582EBC3AD7EBF16 /* es.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = es.lproj; path = Pod/Assets/es.lproj; sourceTree = "<group>"; };
+		F43876A9FCC13C6A90F3D8A47EA50B5F /* UIControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupport.m"; path = "ReactiveCocoa/UIControl+RACSignalSupport.m"; sourceTree = "<group>"; };
+		F4784456047EB0648FEB43746056BB3C /* RACQueueScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACQueueScheduler+Subclass.h"; path = "ReactiveCocoa/RACQueueScheduler+Subclass.h"; sourceTree = "<group>"; };
+		F4FA110D05C65ABC7F72F63FD2C860BE /* safari-7.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "safari-7.png"; path = "Pod/Assets/safari-7.png"; sourceTree = "<group>"; };
+		F503678C4EFDC52B004DCB1A0B228225 /* RACImmediateScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = ReactiveCocoa/RACImmediateScheduler.m; sourceTree = "<group>"; };
+		F527135FA232D5728A653C94B197011C /* RACReturnSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReturnSignal.h; path = ReactiveCocoa/RACReturnSignal.h; sourceTree = "<group>"; };
+		F6D0D95416481B0C0D8EA28D796E88C7 /* ARChromeActivity@2x~ipad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity@2x~ipad.png"; path = "ARChromeActivity/ARChromeActivity@2x~ipad.png"; sourceTree = "<group>"; };
+		F7481C5F920E60874D71CFA0D8E0DCC6 /* RACEmptySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySequence.h; path = ReactiveCocoa/RACEmptySequence.h; sourceTree = "<group>"; };
+		F787BB2D65C142FF059BC79EEF0F70AA /* RACEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = ReactiveCocoa/RACEvent.m; sourceTree = "<group>"; };
+		F7BD85416822118288CF55855BCC81E0 /* NSString+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSupport.m"; path = "ReactiveCocoa/NSString+RACSupport.m"; sourceTree = "<group>"; };
+		F7F24E40BA83A51628B3EEC30C456918 /* ReactiveCocoa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveCocoa.h; path = ReactiveCocoa/ReactiveCocoa.h; sourceTree = "<group>"; };
+		F96B250FD6358B2DF40361ECF724F904 /* ARChromeActivity~ipad.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "ARChromeActivity~ipad.png"; path = "ARChromeActivity/ARChromeActivity~ipad.png"; sourceTree = "<group>"; };
+		F9DA6CAE4C66DB6CE66E9E4C6F0C0D5C /* RACSignalSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignalSequence.m; path = ReactiveCocoa/RACSignalSequence.m; sourceTree = "<group>"; };
+		FA59FE4BFF0BCFDCEC7729C529DCA9BD /* pt.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = pt.lproj; path = Pod/Assets/pt.lproj; sourceTree = "<group>"; };
+		FB526BE4F9FD8AB0EBC92EB95EB9B50D /* ReactiveViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveViewModel.h; path = ReactiveViewModel/ReactiveViewModel.h; sourceTree = "<group>"; };
+		FB724AB83A759E281C60DB2923ADE422 /* vi.lproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = vi.lproj; path = Pod/Assets/vi.lproj; sourceTree = "<group>"; };
+		FE8FE679B677A7E6F7086E8A464613C1 /* RACCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCommand.h; path = ReactiveCocoa/RACCommand.h; sourceTree = "<group>"; };
+		FEB312B74AB90A72954E8E689CE204A0 /* RACMulticastConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = ReactiveCocoa/RACMulticastConnection.m; sourceTree = "<group>"; };
+		FEB614E55CB1AE19C3A5916F1E2E356E /* RACSignalProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = ReactiveCocoa/RACSignalProvider.d; sourceTree = "<group>"; };
+		FED1C042F67A7F13B7F72BA35A22C091 /* UIImagePickerController+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImagePickerController+RACSignalSupport.h"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.h"; sourceTree = "<group>"; };
+		FF17E77ABBD4329BCBCF902078B45C6A /* UIStepper+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIStepper+RACSignalSupport.h"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.h"; sourceTree = "<group>"; };
+		FF9DB25E4A4EA0271BF05C3902A1DC60 /* UIControl+RACSignalSupportPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupportPrivate.h"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		20E2087575CB2DB3A5367AD997C3849B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				58E2099595058B2B538BD5712C529606 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		31B5D696CE8B7930BEAF8396956A49FA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				078C1796B46F28E42761B632156CDE18 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		36C58AFDD241229AB571D0A66B6D4FB4 /* Frameworks */ = {
+		0644A2D8D63081745140D703B4D769C8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5140E0F55C993232D189C0AE16FFCA7F /* Frameworks */ = {
+		146074E818035510BD7EF6361FF095B8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				556689D907BD2318C9A3B1103DC16807 /* Cocoa.framework in Frameworks */,
+				0FE7065CBE46CD422B9563E4178D17E3 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		903E76D5C323554E18392DC27F072E30 /* Frameworks */ = {
+		48625C5396F569E5126020D98049AE7D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB6D3C2DC614C4FD5F998F2D7AE721B8 /* Foundation.framework in Frameworks */,
+				6253CDD55DBD0888D4FB552DAF0AEB35 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B50E38BA603C779A8BA0F6846DDAC9B2 /* Frameworks */ = {
+		77EA035214079B3493072072BA713AA2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				68FC4095C6D86C69EF29CC8D6E85D8B0 /* Foundation.framework in Frameworks */,
+				EC6D4DF8E309B8C8C5FBB118CE1F090D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B8E4290A8EBB6D8C32DDF4FE7491BBBF /* Frameworks */ = {
+		91585807DE0C8450DF19BC98C576A341 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				97E13D8C628AAD4923C9790A2C0263E5 /* Foundation.framework in Frameworks */,
+				67058F0651F8582518598C92995941EB /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BA338BD54352389850C5B489E8DF2AE9 /* Frameworks */ = {
+		91958FD7FD551866096C4ED2FA19D505 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB2FD2992B7019E2FEDD8DC50D377963 /* Foundation.framework in Frameworks */,
+				2250E5AFBE2DFE8691C39EE2A5797D0A /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EF45DA237653577E21470BE03BE16A39 /* Frameworks */ = {
+		A39BC297797D852B4AB00E7A40252D9F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F200241FC463934796295CB3447B3983 /* Cocoa.framework in Frameworks */,
+				20F60B92AEDCF6CDBE9AF94E8C6EF551 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F0123B81C7670E10B4824845BF54A0AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5123FD7574C5A83ECE4A65D44E5B1E16 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5284AF7F25F62C5FD15032F3832685A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB7FD7E4629429C23E541A6A904A4417 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0223FAD3F67E7B81E26F3DCC67DE997C /* no-arc */ = {
+		10B250BC3BBAEB9AE03C22D429B607CE /* ReactiveViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				AF18C68853CE72E437DFBC85139F5431 /* RACObjCRuntime.h */,
-				3DB5C9D377823FC29EDA1D3EE02B0696 /* RACObjCRuntime.m */,
+				FB526BE4F9FD8AB0EBC92EB95EB9B50D /* ReactiveViewModel.h */,
+				B61AD602484929783B7B20F2DA803D39 /* RVMViewModel.h */,
+				961458246F38388E8FC56D87653532B5 /* RVMViewModel.m */,
+				1465534E053CBC759579F4566449C3A2 /* Support Files */,
 			);
-			name = "no-arc";
+			path = ReactiveViewModel;
 			sourceTree = "<group>";
 		};
-		0911B833945CE1B823B638AB3403B37A /* OS X */ = {
+		1465534E053CBC759579F4566449C3A2 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				289D0DADBC9F1F6E5EE19A5D2FE7A7E9 /* Cocoa.framework */,
+				A8B9291624E54577E8A2B92078724D9D /* Pods-iOSDemo-ReactiveViewModel.xcconfig */,
+				7DD67604E8C1281015A4D4D5C6F21EAC /* Pods-iOSDemo-ReactiveViewModel-dummy.m */,
+				9DFAD16541518CE86C35D592524B3145 /* Pods-iOSDemo-ReactiveViewModel-prefix.pch */,
+				1CE1CC2F4F712805D1D9AF43C881D944 /* Pods-OSXDemo-ReactiveViewModel.xcconfig */,
+				4A698716124DA0D099D661DC12C22E55 /* Pods-OSXDemo-ReactiveViewModel-dummy.m */,
+				6078BEECC76E2479A1408F40A85F8EB5 /* Pods-OSXDemo-ReactiveViewModel-prefix.pch */,
 			);
-			name = "OS X";
+			name = "Support Files";
+			path = "../Target Support Files/Pods-OSXDemo-ReactiveViewModel";
 			sourceTree = "<group>";
 		};
-		3340C3EA59979AE222351EB81618E291 /* Resources */ = {
+		3646D0BBF7F88AE337C185CFE71A2916 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				6B796E4AD2FB84A58C72649E4DFECBE5 /* ARChromeActivity.png */,
-				12BEF5B1C0CABED1449FED5B593416CC /* ARChromeActivity@2x.png */,
-				13815EB8BFDF409CDF8521F44EBDD336 /* ARChromeActivity@2x~ipad.png */,
-				874CF60F31BA05D83C495EF7777C689E /* ARChromeActivity@3x.png */,
-				98C10D9070B172B8B68AAF9E2AEFB805 /* ARChromeActivity@3x~ipad.png */,
-				5E13A98C680E9E8010B34C6F3F8A37AF /* ARChromeActivity~ipad.png */,
+				B2EF32B1C7762238C3D78D165AA7F738 /* cs.lproj */,
+				97642E37E12ECB7FB2CD3316445C79D6 /* de.lproj */,
+				B292322EFE57C446C12BA9709E048CA2 /* en.lproj */,
+				F36584392924EC7C3582EBC3AD7EBF16 /* es.lproj */,
+				4C1BD7294254C0E4AF6523856B9E5721 /* eu.lproj */,
+				77EF4D97CD37FB38AB3FBC7D2CEAE15D /* fi.lproj */,
+				54862ADDA9043F400532C3DD8D77360E /* fr.lproj */,
+				F2E0E11331722D7908C2B0DF7D058C0E /* it.lproj */,
+				814C4B768B047AAD56C86B887F508F82 /* ja.lproj */,
+				4EB8A204E9E6FAB7B77B4E7061D0424E /* ko.lproj */,
+				C7A4C57571FA79FC725C3DD83AE46A2A /* nl.lproj */,
+				5A0409F7C17631138C7619B3975A4609 /* no.lproj */,
+				DB49180EF6BE193A0E292190BCC54858 /* pl.lproj */,
+				FA59FE4BFF0BCFDCEC7729C529DCA9BD /* pt.lproj */,
+				6149DD13FC4F4F6B15F2F31AE1A50C61 /* ru.lproj */,
+				A8EE0910F31EB2C2E3E1D1B8D3781147 /* safari.png */,
+				F4FA110D05C65ABC7F72F63FD2C860BE /* safari-7.png */,
+				D5426EAEDC82A4C05E3E03F672B22BD3 /* safari-7@2x.png */,
+				3CCF3707FAD8F53466D8F2DC5C738EE0 /* safari-7@3x.png */,
+				DA8BAB431223B649FA38C48C9D599DA0 /* safari-7~iPad.png */,
+				5A0875D187B7E0F4E836D11CDA78E4FE /* safari-7~iPad@2x.png */,
+				E19E9A73E2B8495931B5F0675B79099B /* safari@2x.png */,
+				8E78B3714694BDAF079C4BEC728DD469 /* safari@3x.png */,
+				E68E255E47AD78C33C220D115C592450 /* safari~iPad.png */,
+				B2457A8D3868D57EF8E9583D5FC4A567 /* safari~iPad@2x.png */,
+				D3F8A4E955AF309264630F97B3AA7668 /* sk.lproj */,
+				290377AC0D4A8B7D3F74623524E45DB7 /* sv.lproj */,
+				FB724AB83A759E281C60DB2923ADE422 /* vi.lproj */,
+				23FE51336E8B43D46BA5599423B335B2 /* zh_CN.lproj */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		378272E5969B6BF0C0B4FAABBDC88A11 /* ReactiveCocoa */ = {
+		3AEF7D761E8EA8419BB4A7000AB770CB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C13EB7E8DCCF189ACA0E776D6808AE6B /* Core */,
-				D1B887DA3785F4ADCD3D01DA1B3331EA /* Support Files */,
-				45E5D36B186D0FACD2AFFF32CC638E3C /* UI */,
-				0223FAD3F67E7B81E26F3DCC67DE997C /* no-arc */,
-			);
-			path = ReactiveCocoa;
-			sourceTree = "<group>";
-		};
-		39F9854361F55D63AB6E4D3EA5BC5728 /* Pods-iOSDemo */ = {
-			isa = PBXGroup;
-			children = (
-				60680B2809624648BD2BE9258E14331E /* Pods-iOSDemo-acknowledgements.markdown */,
-				0495AA2804258AAEE06B9927011E5317 /* Pods-iOSDemo-acknowledgements.plist */,
-				0447E5038A8FFAE26550600D09F65E8D /* Pods-iOSDemo-dummy.m */,
-				A8D283B6FCCEFCDCD8E834B9AE70F93D /* Pods-iOSDemo-resources.sh */,
-				FF6D9559B18EB2D5592A1B0B4FA52A22 /* Pods-iOSDemo.debug.xcconfig */,
-				89B1E455857D830E6B9D0113F96F2D48 /* Pods-iOSDemo.release.xcconfig */,
-			);
-			name = "Pods-iOSDemo";
-			path = "Target Support Files/Pods-iOSDemo";
-			sourceTree = "<group>";
-		};
-		3C6DAA7AC704E24244A26D600ED0D0DA /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				47EB64784FAA248265A307B57F9FCF39 /* ARChromeActivity.xcconfig */,
-				7AEFE7B6B45C74503DEA67CBE7139D37 /* ARChromeActivity-Private.xcconfig */,
-				2DAF5A464A2AEA238D8C9013006524F0 /* ARChromeActivity-dummy.m */,
-				D1941C39AED6981364FAE3C563FA9453 /* ARChromeActivity-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/ARChromeActivity";
-			sourceTree = "<group>";
-		};
-		3DD667CFFBC8AD78945A7D0109E7F227 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				A0110258D42B9DC895DFB8F02677B262 /* Pods-OSXDemo */,
-				39F9854361F55D63AB6E4D3EA5BC5728 /* Pods-iOSDemo */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		45E5D36B186D0FACD2AFFF32CC638E3C /* UI */ = {
-			isa = PBXGroup;
-			children = (
-				3925C05522371D1E4E40F4AE5795282E /* MKAnnotationView+RACSignalSupport.h */,
-				CBBAA78ABC4464F0DF879FE45A3C3759 /* MKAnnotationView+RACSignalSupport.m */,
-				949E114381CFA92E910684B8BEAB0E59 /* NSControl+RACCommandSupport.h */,
-				C8C498C43C287C5F801A31F393EA6D30 /* NSControl+RACCommandSupport.m */,
-				272BAE73358159A37442D7A772BC9C76 /* NSControl+RACTextSignalSupport.h */,
-				D2050276400F6EB01867BAD68FB2E1A0 /* NSControl+RACTextSignalSupport.m */,
-				7287809267EFD8915EE4B6D61DE460C3 /* NSObject+RACAppKitBindings.h */,
-				9F0A2008D479294BC6FF776848C3C083 /* NSObject+RACAppKitBindings.m */,
-				6DFB677FA0CF9D2064F007BB1FB12AFF /* NSText+RACSignalSupport.h */,
-				17DBCD15D00C9DA12A3DAE0AB7469B56 /* NSText+RACSignalSupport.m */,
-				15C939B20231938145B5341121598FF1 /* UIActionSheet+RACSignalSupport.h */,
-				265A63E9272E1C7B27874A0898146FA0 /* UIActionSheet+RACSignalSupport.m */,
-				F91F93B244BE6B9E4C89AC52949C04E1 /* UIAlertView+RACSignalSupport.h */,
-				886D59625C86AA324B6184EF0649CA6F /* UIAlertView+RACSignalSupport.m */,
-				2BE1D100E476FF9FDB4D86278F848CA3 /* UIBarButtonItem+RACCommandSupport.h */,
-				DB3482F070F513F530E64649A484F827 /* UIBarButtonItem+RACCommandSupport.m */,
-				53EC49D13C8ABF07761F08B8E25C133C /* UIButton+RACCommandSupport.h */,
-				88840275991F5A2C7F87BDF4FF477026 /* UIButton+RACCommandSupport.m */,
-				2DC2EF9D9154E68ED17F779DA1915E8B /* UICollectionReusableView+RACSignalSupport.h */,
-				EE008F0470C6E65A6125B07D4D9288A8 /* UICollectionReusableView+RACSignalSupport.m */,
-				0D4340B272F3EE69DFBCFE995319DF31 /* UIControl+RACSignalSupport.h */,
-				278695DD4B5B44CDADB306E87A50D151 /* UIControl+RACSignalSupport.m */,
-				0167F063CC719C0E1682227664568F58 /* UIControl+RACSignalSupportPrivate.h */,
-				3428AFDB0B65A20D06339592AF1D9AEB /* UIControl+RACSignalSupportPrivate.m */,
-				AFA9C4124A0E2996DBBCFE875F3C60B9 /* UIDatePicker+RACSignalSupport.h */,
-				FCF7EA8B6B5063BCB47DAA1613D288FF /* UIDatePicker+RACSignalSupport.m */,
-				ECAE97031F73CD25E5B79FF2A0A35462 /* UIGestureRecognizer+RACSignalSupport.h */,
-				BC3F321D5887C075F31139B5975DFA72 /* UIGestureRecognizer+RACSignalSupport.m */,
-				40E5E0E6357BD0D0AC1C2C13C550346B /* UIImagePickerController+RACSignalSupport.h */,
-				F73BBFE23390E4C468B17EA660A986A8 /* UIImagePickerController+RACSignalSupport.m */,
-				F19E5E21542A06A70630A9CB46E48761 /* UIRefreshControl+RACCommandSupport.h */,
-				52FFAEBE948518482803379C80F8A38D /* UIRefreshControl+RACCommandSupport.m */,
-				8D2D0E557458973ED0022FE510725842 /* UISegmentedControl+RACSignalSupport.h */,
-				A349EB05ED550FE9CE77FD2B20C35BC0 /* UISegmentedControl+RACSignalSupport.m */,
-				2D1044CE4AC4CE6AE373041E3567AC9F /* UISlider+RACSignalSupport.h */,
-				D07C4A22E4B34D3CA20F749A5BB3627A /* UISlider+RACSignalSupport.m */,
-				DD39CA030B4599162C3E822EB80CBC33 /* UIStepper+RACSignalSupport.h */,
-				44CA503643A7653AC1AEA112A4323D9D /* UIStepper+RACSignalSupport.m */,
-				F20FD0A8EDF787FA061448C874715155 /* UISwitch+RACSignalSupport.h */,
-				A802CA6FA3D8A8488065C6B1378DB7B6 /* UISwitch+RACSignalSupport.m */,
-				9D3BEAC6E02413CE43B98E3A3482C2BA /* UITableViewCell+RACSignalSupport.h */,
-				973754C87D63265F338926EA6894018D /* UITableViewCell+RACSignalSupport.m */,
-				3ED934E6B939034E1577D7B0A469707D /* UITableViewHeaderFooterView+RACSignalSupport.h */,
-				B4F8F5C9B68C93238892F0A78C3D6A6D /* UITableViewHeaderFooterView+RACSignalSupport.m */,
-				72758B728D8AB6C632836340DCD900DE /* UITextField+RACSignalSupport.h */,
-				78CD3D7A3E70AB0C7A651F66C9978667 /* UITextField+RACSignalSupport.m */,
-				E5B2EFE7FE8D884045E8A92FFF76F2A4 /* UITextView+RACSignalSupport.h */,
-				31A3BFE79097E1427A83176856BB8864 /* UITextView+RACSignalSupport.m */,
-			);
-			name = UI;
-			sourceTree = "<group>";
-		};
-		55A5916152CCA72407856BB1B82BFC50 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				0911B833945CE1B823B638AB3403B37A /* OS X */,
-				A5BB5C68FBB62288EBB469C76BD93757 /* iOS */,
+				7AD470ACF4E5545C3E4A621BD6E0A529 /* iOS */,
+				9304B30CB87FDB77B6CEE9FB6B800855 /* OS X */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		5C48A4592E22B1CA2F593E2595339F2B /* ReactiveViewModel */ = {
+		3CD9CB59FBF96E613D56C11A1864633F /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				4DF2EF1B391D591BAF3AED68B9C6CD4A /* RVMViewModel.h */,
-				59AAC6F913A5EE37789B86850AAF49FC /* RVMViewModel.m */,
-				DDFB2D8D994759171B928C0C62A09628 /* ReactiveViewModel.h */,
-				F74EA9E98B373D3D87F447B7875E8770 /* Support Files */,
+				023707F4D1F3F4E8DCE0F0A8DDC4704F /* TUSafariActivity.xcconfig */,
+				9D95F780B39ACB720E40BA9DFC8A8B3D /* TUSafariActivity-dummy.m */,
+				A1189943E112E96ADAD205CBC31DDB8E /* TUSafariActivity-prefix.pch */,
 			);
-			path = ReactiveViewModel;
+			name = "Support Files";
+			path = "../Target Support Files/TUSafariActivity";
+			sourceTree = "<group>";
+		};
+		3EACF04886108DD9873D5B1DCBC23E38 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				0F7B7E42281EB96C9DCC4821797E4859 /* ARChromeActivity.png */,
+				60DB0F6D74899A76896CCA8FA33FB5D1 /* ARChromeActivity@2x.png */,
+				F6D0D95416481B0C0D8EA28D796E88C7 /* ARChromeActivity@2x~ipad.png */,
+				B003F595C86326A2C6B2CCDB57B63909 /* ARChromeActivity@3x.png */,
+				537BAC5578E5933475936BC6122B77BF /* ARChromeActivity@3x~ipad.png */,
+				F96B250FD6358B2DF40361ECF724F904 /* ARChromeActivity~ipad.png */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		46AD6515B2FE874D40F134FC4E7341E4 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				E3D1145FCAFD92D8CA5612CA6A935B5E /* MKAnnotationView+RACSignalSupport.h */,
+				24F544DB0ACE3BB3689704BDA915E425 /* MKAnnotationView+RACSignalSupport.m */,
+				A95C2AF877BDB7D5F87CE30D15799955 /* NSControl+RACCommandSupport.h */,
+				4C2D246BEC588B5CC01B139007AB04DC /* NSControl+RACCommandSupport.m */,
+				87ACCBB15020B3221BA89AD0523AED5D /* NSControl+RACTextSignalSupport.h */,
+				A05624F1E4BDA59E7E6EF34F30754B35 /* NSControl+RACTextSignalSupport.m */,
+				E25F4518F3D58F73E2CA3AA04EB74533 /* NSObject+RACAppKitBindings.h */,
+				7CD59E0658C4F4D324F9E9FF5B12B04E /* NSObject+RACAppKitBindings.m */,
+				C023BADA5CEDAA037E32E7E73B35E716 /* NSText+RACSignalSupport.h */,
+				BBAADE0D8B83A9E16996B3C1F1A0466A /* NSText+RACSignalSupport.m */,
+				43DF6E8AB5C2E98D00731708C6C929B5 /* UIActionSheet+RACSignalSupport.h */,
+				38414290241A098A8827B0B39859EEB6 /* UIActionSheet+RACSignalSupport.m */,
+				B86E5079A6E12FC0EA227278CDFBC9BC /* UIAlertView+RACSignalSupport.h */,
+				09605F595D68B72B357FEDD46D9C25BD /* UIAlertView+RACSignalSupport.m */,
+				C1D2D16F66FD32C8B2186965C10DB8A5 /* UIBarButtonItem+RACCommandSupport.h */,
+				45E7B0AD2DAFA22302B74318C762D5AC /* UIBarButtonItem+RACCommandSupport.m */,
+				75797F9D856D0221DB1D824DA973043C /* UIButton+RACCommandSupport.h */,
+				62CBDC615FBAF562278C0677F12925BD /* UIButton+RACCommandSupport.m */,
+				BFBB516C133840F42F99C865C2B96158 /* UICollectionReusableView+RACSignalSupport.h */,
+				AC38A0A06F7EAD82DB96A60257AE9453 /* UICollectionReusableView+RACSignalSupport.m */,
+				C9367045BB3B2BBFCB5B7595E1F4BD08 /* UIControl+RACSignalSupport.h */,
+				F43876A9FCC13C6A90F3D8A47EA50B5F /* UIControl+RACSignalSupport.m */,
+				FF9DB25E4A4EA0271BF05C3902A1DC60 /* UIControl+RACSignalSupportPrivate.h */,
+				A320927BAAE1EA13F662AC3CC75B6EBE /* UIControl+RACSignalSupportPrivate.m */,
+				9DCAF96FE449F756C7AE83F57E520DBB /* UIDatePicker+RACSignalSupport.h */,
+				6CE87DCE07C151060F4659AF2B7F574F /* UIDatePicker+RACSignalSupport.m */,
+				2247755278162C2D9FEDE052ABF2E841 /* UIGestureRecognizer+RACSignalSupport.h */,
+				345CF13CD8BC2C87402001DBFD7FB227 /* UIGestureRecognizer+RACSignalSupport.m */,
+				FED1C042F67A7F13B7F72BA35A22C091 /* UIImagePickerController+RACSignalSupport.h */,
+				B31486C033A0039473C5310468ACDA47 /* UIImagePickerController+RACSignalSupport.m */,
+				30E13086600B1F4EA03B6EEDB29077BE /* UIRefreshControl+RACCommandSupport.h */,
+				A7B26AC0B4E10A34562A337CE79FF1BB /* UIRefreshControl+RACCommandSupport.m */,
+				0E86673B7AB97878628F760C330A46F4 /* UISegmentedControl+RACSignalSupport.h */,
+				2250CB4796604C410705A22C5DC5348C /* UISegmentedControl+RACSignalSupport.m */,
+				4E1A33D68D81A502341B21E1B186CDFF /* UISlider+RACSignalSupport.h */,
+				D580D1996B863820626C5132ACF88328 /* UISlider+RACSignalSupport.m */,
+				FF17E77ABBD4329BCBCF902078B45C6A /* UIStepper+RACSignalSupport.h */,
+				BFA778F7CC5142102F0E624196A066B7 /* UIStepper+RACSignalSupport.m */,
+				2DAC67E544DA9537C9F6D05DDCAB9F38 /* UISwitch+RACSignalSupport.h */,
+				12735A6B84F1BCC09F1656B9CBA9FEF3 /* UISwitch+RACSignalSupport.m */,
+				3104056F51F99CD36790AFB5C0C120FD /* UITableViewCell+RACSignalSupport.h */,
+				1A702BC01C7723F483E2D751160905F5 /* UITableViewCell+RACSignalSupport.m */,
+				023CFD62F7DB3A7BF00BDC55B7AC66F2 /* UITableViewHeaderFooterView+RACSignalSupport.h */,
+				2FB4497EAABD11BAF2E2889717CF3B36 /* UITableViewHeaderFooterView+RACSignalSupport.m */,
+				3E155750D7EF7A1BB4E4293248F36310 /* UITextField+RACSignalSupport.h */,
+				D52EABF33B4E4C1909CE50479DCB42EB /* UITextField+RACSignalSupport.m */,
+				1564204204A9EA7E397A5928E13DDF19 /* UITextView+RACSignalSupport.h */,
+				6CDED8AE31BDD914BEB8740875B4A18C /* UITextView+RACSignalSupport.m */,
+			);
+			name = UI;
+			sourceTree = "<group>";
+		};
+		5960119E3A90392202A4AAAC32D3CF2C /* Pods-OSXDemo */ = {
+			isa = PBXGroup;
+			children = (
+				8D5227FA42BD8ABC205A4B2C409C968A /* Pods-OSXDemo-acknowledgements.markdown */,
+				B43EF41FED773390D1BDD74A471C83A8 /* Pods-OSXDemo-acknowledgements.plist */,
+				2E75209E0013BEB19BBBA0C6905C6990 /* Pods-OSXDemo-dummy.m */,
+				87292D5B34A04F71F3E30AE616CA7257 /* Pods-OSXDemo-frameworks.sh */,
+				10981694A33D1868AA69AEC7EA0403AD /* Pods-OSXDemo-resources.sh */,
+				56463C80746C7F6187B968577A3272BD /* Pods-OSXDemo.debug.xcconfig */,
+				54ED4B2C5C52611104E3F7E352C89ACC /* Pods-OSXDemo.release.xcconfig */,
+			);
+			name = "Pods-OSXDemo";
+			path = "Target Support Files/Pods-OSXDemo";
+			sourceTree = "<group>";
+		};
+		5B36CC5187501DBA89C1DF815265CDB2 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				EDC66583BA861E1C0C521F9226134C10 /* Pods-iOSDemo */,
+				5960119E3A90392202A4AAAC32D3CF2C /* Pods-OSXDemo */,
+			);
+			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
 		756F743780BE7B4FA8B728DEF666D450 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D6E342895E7A7DE591149630A68FA799 /* ARChromeActivity */,
-				378272E5969B6BF0C0B4FAABBDC88A11 /* ReactiveCocoa */,
-				5C48A4592E22B1CA2F593E2595339F2B /* ReactiveViewModel */,
-				8E198574DEA72C75DC40E451159E5809 /* TUSafariActivity */,
+				8E27D259494053C335288F0326DB4D45 /* ARChromeActivity */,
+				BA5AA96D77292F4B5C56879B2500DEB0 /* ReactiveCocoa */,
+				10B250BC3BBAEB9AE03C22D429B607CE /* ReactiveViewModel */,
+				E4E62DD732FFA08D8A6EAB5F1F27C7C8 /* TUSafariActivity */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		7AD470ACF4E5545C3E4A621BD6E0A529 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2F426C20791C2C776D6B81F15C1EA8A5 /* Foundation.framework */,
+			);
+			name = iOS;
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
 				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
-				55A5916152CCA72407856BB1B82BFC50 /* Frameworks */,
+				3AEF7D761E8EA8419BB4A7000AB770CB /* Frameworks */,
 				756F743780BE7B4FA8B728DEF666D450 /* Pods */,
-				CCA510CFBEA2D207524CDA0D73C3B561 /* Products */,
-				3DD667CFFBC8AD78945A7D0109E7F227 /* Targets Support Files */,
+				9D00EA2FC3F4ADBADB491D2463A26012 /* Products */,
+				5B36CC5187501DBA89C1DF815265CDB2 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		8E198574DEA72C75DC40E451159E5809 /* TUSafariActivity */ = {
+		89CD5E48CCD0C0ADB32F4CD75922CC7A /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				78E363F84E058AE357AA0EDAA2EEB566 /* TUSafariActivity.h */,
-				477DFED5355D2A19F8C1D874513C0734 /* TUSafariActivity.m */,
-				F77D0F4758CA1A31EC1B3E9C12D78CB3 /* Resources */,
-				DD8B3F99C64FE593550BCEF9194A661A /* Support Files */,
-			);
-			path = TUSafariActivity;
-			sourceTree = "<group>";
-		};
-		A0110258D42B9DC895DFB8F02677B262 /* Pods-OSXDemo */ = {
-			isa = PBXGroup;
-			children = (
-				005DF66FD4CD7616BE1A391EEB4B3213 /* Pods-OSXDemo-acknowledgements.markdown */,
-				3D8A04C09132927F04FD62A4F448D441 /* Pods-OSXDemo-acknowledgements.plist */,
-				E1F9B1B9A7F6D58C8C3B39A6FF22D496 /* Pods-OSXDemo-dummy.m */,
-				BE5AB37C99FA6C028583C29D7E72545D /* Pods-OSXDemo-resources.sh */,
-				ED900941E1DC1ABFB5B06F715C48ECDF /* Pods-OSXDemo.debug.xcconfig */,
-				EE5C78EC2315BB1CC10727CDF3A338ED /* Pods-OSXDemo.release.xcconfig */,
-			);
-			name = "Pods-OSXDemo";
-			path = "Target Support Files/Pods-OSXDemo";
-			sourceTree = "<group>";
-		};
-		A5BB5C68FBB62288EBB469C76BD93757 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				4D695E705EE91C91807A84FDE29F89FA /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		C13EB7E8DCCF189ACA0E776D6808AE6B /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				C6A05A695D82F88434D0A912EC031EE2 /* NSArray+RACSequenceAdditions.h */,
-				6F2FC7FE2ECDAD999DC1FF54627A29B1 /* NSArray+RACSequenceAdditions.m */,
-				AC122118585236D0F4DA3B10C1245C66 /* NSData+RACSupport.h */,
-				09B6B1659018C794FCB6E287462BC8B2 /* NSData+RACSupport.m */,
-				5879B8B48431419CE4AF8720DD96176A /* NSDictionary+RACSequenceAdditions.h */,
-				6846730D0A4DAA2F536A7682FC11C5CF /* NSDictionary+RACSequenceAdditions.m */,
-				16764EA1D4AA994848588AEE13511ABC /* NSEnumerator+RACSequenceAdditions.h */,
-				81E98B187F4F5D954A297B69765400C3 /* NSEnumerator+RACSequenceAdditions.m */,
-				9A7D8D3A7EEEB292506086DF3C3AA829 /* NSFileHandle+RACSupport.h */,
-				73B3FCC97278A75478097B6CC0768F90 /* NSFileHandle+RACSupport.m */,
-				943F9021136C30FD9BC0FE238FEDCA94 /* NSIndexSet+RACSequenceAdditions.h */,
-				96FC8B8E155AC9762A2AFB38667B41A0 /* NSIndexSet+RACSequenceAdditions.m */,
-				DE451BE988A97C4BD2DF85BAA4177D9D /* NSInvocation+RACTypeParsing.h */,
-				03BDBC76E6B2BC3A7BA3276FD0D2F068 /* NSInvocation+RACTypeParsing.m */,
-				24A8C000C2435C5362CBC8986C8B5773 /* NSNotificationCenter+RACSupport.h */,
-				B18349B085B61E9C4B610A155E031748 /* NSNotificationCenter+RACSupport.m */,
-				831687FB5D10486613F3DA0B61A46C70 /* NSObject+RACDeallocating.h */,
-				CEEB6CE9BFE79CB52095223105869FD5 /* NSObject+RACDeallocating.m */,
-				B5188C621CB3ACAC070ADD31784B8F68 /* NSObject+RACDescription.h */,
-				AC72ABC92F84FC70AD5E2503BCA885B8 /* NSObject+RACDescription.m */,
-				6CC070D947F559BC5A3222915ABE78CD /* NSObject+RACKVOWrapper.h */,
-				81FB5BCF7A667679A3A31516968CAED2 /* NSObject+RACKVOWrapper.m */,
-				BCE24908E1DD76F05BE3BFD1156B95CD /* NSObject+RACLifting.h */,
-				F018065A9386572D09E5322F0115945E /* NSObject+RACLifting.m */,
-				5489A687C2806D8DA45E37B43109B3D0 /* NSObject+RACPropertySubscribing.h */,
-				C1E20C597B94D0683ECED7071C31C4A7 /* NSObject+RACPropertySubscribing.m */,
-				5A3AFFCB336D6A2A8FBE001E2BD3BB8F /* NSObject+RACSelectorSignal.h */,
-				66D59063E166FE928FE993BCC3BE236B /* NSObject+RACSelectorSignal.m */,
-				17A9C9D0CFDFC9414CCB422577B05CB0 /* NSOrderedSet+RACSequenceAdditions.h */,
-				3ADBDA7231382A4A565B27790B0730BE /* NSOrderedSet+RACSequenceAdditions.m */,
-				6E4841A2F2258085854D3651DD1C78D3 /* NSSet+RACSequenceAdditions.h */,
-				8989322B3B83978F83AD7CB0361A34A1 /* NSSet+RACSequenceAdditions.m */,
-				6BFAAF0510C13BE305EDC1143245AF80 /* NSString+RACKeyPathUtilities.h */,
-				C494068064B50BA8BBF11982F37B3F12 /* NSString+RACKeyPathUtilities.m */,
-				E88B0ADFBF294D399B6F67BBAE3BEB27 /* NSString+RACSequenceAdditions.h */,
-				74C6A8D1D2A7072FC25CAE38632C18EC /* NSString+RACSequenceAdditions.m */,
-				F485BB2CCC59F7B5B1F24EE94420556C /* NSString+RACSupport.h */,
-				2FC799242719D2C5809E8D041BCF339E /* NSString+RACSupport.m */,
-				4B934C307FBF0D1F27BFFAAAB37ED96E /* NSURLConnection+RACSupport.h */,
-				003E242E42E67E7B590471A1B061D103 /* NSURLConnection+RACSupport.m */,
-				B82CBB7E3811E1ABDB91CC76A2CE1DF4 /* NSUserDefaults+RACSupport.h */,
-				B9441D0CEFAB6891A4BD48BFA9A0DD90 /* NSUserDefaults+RACSupport.m */,
-				5189B2031A207A8FA6CD5C0A66929D64 /* RACArraySequence.h */,
-				3DB823F76AF7C16F2EBC395C7D452B82 /* RACArraySequence.m */,
-				D543B10369FF781F07957B7A26041A56 /* RACBehaviorSubject.h */,
-				93C536457A6D4A275CAF5E8BC886DD77 /* RACBehaviorSubject.m */,
-				93EEC199A454683642D9A27AB1E9B77C /* RACBlockTrampoline.h */,
-				D48ADC77497F585ADCB941D1F0B0029F /* RACBlockTrampoline.m */,
-				4324ABDECD6CDE80EE4D42B3ED108293 /* RACChannel.h */,
-				D81C0467590F8EE5A3FC23E4B050F45D /* RACChannel.m */,
-				A097BAAAEA31918AC85B517BD3C79DEA /* RACCommand.h */,
-				D7F88AEE42657D472B2992F29311B85C /* RACCommand.m */,
-				C6EAE038798890FDE806B30250E09DAD /* RACCompoundDisposable.h */,
-				CDB021FA2483DA1E9E846A0C737FA8A6 /* RACCompoundDisposable.m */,
-				6637492CC2B364C39D40D5351D972947 /* RACCompoundDisposableProvider.d */,
-				197B104667FD34E79A9F68D5DA21CE11 /* RACDelegateProxy.h */,
-				5BDEE4AEB45BD91ED2AC28A8136D436A /* RACDelegateProxy.m */,
-				75D7D01A90BECF813F328A2DA082DB42 /* RACDisposable.h */,
-				6D6B4CEF46ED4BEDC0BF8FD80520A060 /* RACDisposable.m */,
-				188D4EA11349A675878B1C157EAC57EC /* RACDynamicSequence.h */,
-				8879B7353BAD1C287FC4ACDC3DAC37A2 /* RACDynamicSequence.m */,
-				65EE3C5478E31D18F80192C9E019DF17 /* RACDynamicSignal.h */,
-				5AFE052DA2259F4D29680A0F0F37B73D /* RACDynamicSignal.m */,
-				72E83AE4CD7EED36A7C6347CE4378C27 /* RACEXTKeyPathCoding.h */,
-				B5B459CB97CF9605C48D9E36094E5CB7 /* RACEXTRuntimeExtensions.h */,
-				6C99A36591AF5CB5804BAA9F521FB5E7 /* RACEXTRuntimeExtensions.m */,
-				A8CC845AB300C07D951F6F71237265BF /* RACEXTScope.h */,
-				18DDDDE586DBD26006146C2C58919983 /* RACEagerSequence.h */,
-				1363FC19E200CE140654E63C0DDB6662 /* RACEagerSequence.m */,
-				4257FEA86FA90F2B77C7278E29858092 /* RACEmptySequence.h */,
-				CF9CE224D370EB567CAD58850C053B1C /* RACEmptySequence.m */,
-				16F9A475AFF0BFD5183F7EF312078B2E /* RACEmptySignal.h */,
-				B0D62EAC04D62A8F469D18ADB6E602FE /* RACEmptySignal.m */,
-				F69AD0A69C7E7090F19429598DD17BB6 /* RACErrorSignal.h */,
-				7856AC70AFAE04D415C40B999A8567D9 /* RACErrorSignal.m */,
-				CD013F07826A449FCBB31AB11C05472C /* RACEvent.h */,
-				2A50CB73B740D29B17FCBB116B6665E9 /* RACEvent.m */,
-				1C4C49DE77E3F848A81F428F34E79463 /* RACGroupedSignal.h */,
-				1ED77FF9159C7E09FE907DB65F51B251 /* RACGroupedSignal.m */,
-				78FCACA8F1F7541CADB0D6EE2AA02C57 /* RACImmediateScheduler.h */,
-				1B8C27EA6E4BFED387A9E1B3123825B0 /* RACImmediateScheduler.m */,
-				76C7E3E32CB66CAB21651A04577BFDE2 /* RACIndexSetSequence.h */,
-				DD5D0F6CABD12A493055F2BE8D9FF91F /* RACIndexSetSequence.m */,
-				E30E4F67358DF287E33B991CD7D35C08 /* RACKVOChannel.h */,
-				D1AEECD7595E35FEBC1CFD08D1B8E5AA /* RACKVOChannel.m */,
-				7961AEC15563146002A5BF0D6DF6115F /* RACKVOProxy.h */,
-				54BCEF405EA3B7D1B643D1ABC8CA1C5A /* RACKVOProxy.m */,
-				C42B476B11FC0AD93DECB928A7853D62 /* RACKVOTrampoline.h */,
-				9E039F964524B2DCBF9C0988486E8EEB /* RACKVOTrampoline.m */,
-				02AB9A3D8C18D72585A9345858E3951C /* RACMulticastConnection.h */,
-				39235E7CBD2CA2BB9EA7CABEA3B918D9 /* RACMulticastConnection.m */,
-				35B8D30589207A29D93544A443730717 /* RACMulticastConnection+Private.h */,
-				8C72957053349288966C5D4BD24E84C8 /* RACPassthroughSubscriber.h */,
-				6DC8652C1E7FCFDDA8BF8790D9B7F54E /* RACPassthroughSubscriber.m */,
-				1FEFE70E9171906FCD1DC5624071DEFC /* RACQueueScheduler.h */,
-				D3C2798FF9D596802406300C7E8723BA /* RACQueueScheduler.m */,
-				3EFA06C193D892B97CAAC623D521393E /* RACQueueScheduler+Subclass.h */,
-				FDF9280BE17056BFCBB44C11A3F7C0B3 /* RACReplaySubject.h */,
-				8773FB8EDA1EDABE8A2C78D2D61A16AB /* RACReplaySubject.m */,
-				EFE63862E8E1599ED15D1760E1765BA1 /* RACReturnSignal.h */,
-				347410A7B054CC21BBB4EF2C83EC16B5 /* RACReturnSignal.m */,
-				90148881F051DCFFF1A83F567E2F0339 /* RACScheduler.h */,
-				1C35DBFCA5B591C7CE37DCBE48D1625C /* RACScheduler.m */,
-				CB9A46F76CA8D03A47DB02342073CCB7 /* RACScheduler+Private.h */,
-				E3B3D473D1CAF17619F31AF002814899 /* RACScheduler+Subclass.h */,
-				B0F89EAD6445D20525C6617CDCF40E18 /* RACScopedDisposable.h */,
-				4DE386ED3892B3192E2AA1E3E04029B5 /* RACScopedDisposable.m */,
-				69BBD58C3874DD439EBCCAC57098AE21 /* RACSequence.h */,
-				B9643DB88DE3F7C350CA02DB559AF182 /* RACSequence.m */,
-				F04858660A0ACDD23036F70195F1F0AD /* RACSerialDisposable.h */,
-				9272A08E478EFC8956C985469864CCC7 /* RACSerialDisposable.m */,
-				86CE32DE04525C8C4C27F140E6FBB82A /* RACSignal.h */,
-				15D14F53D043C5F0D3F9EB867E7D3FDA /* RACSignal.m */,
-				3D400F363D8EA6A70892C39ACFE82D97 /* RACSignal+Operations.h */,
-				7DC827809B5D9224B71EFAEEE7560F7F /* RACSignal+Operations.m */,
-				B1B8861A6B229F818BCE2EC17ECEA114 /* RACSignalProvider.d */,
-				CC3D4A780B8A8DFCB0E30FC6C2F1A0B2 /* RACSignalSequence.h */,
-				A190EEABE930390FB1404033B0E34352 /* RACSignalSequence.m */,
-				46AC114C2E3CBA44EB74C95EC0C59360 /* RACStream.h */,
-				B0750FD4759F28C8D918027C7C238616 /* RACStream.m */,
-				8FA723FFA34526F62A03A19D2E204E56 /* RACStream+Private.h */,
-				C05A51FD36FDD375DFE9198B8B0FF259 /* RACStringSequence.h */,
-				25D4CC1B6651C94C90A57E1DF2A80EB1 /* RACStringSequence.m */,
-				0567CDE373FFE56F0E721BE120EB1E95 /* RACSubject.h */,
-				0935FDF3A822645B87AC32ACEAD9F1EB /* RACSubject.m */,
-				3F99F0A6FFDB81788747F8A3171C270A /* RACSubscriber.h */,
-				B4781EF1C6C2425DA7FF8C11B0FE4567 /* RACSubscriber.m */,
-				D27AD87B3E25CC9627832153765D4939 /* RACSubscriber+Private.h */,
-				EA79360878BC8A37BA63762482E52EE1 /* RACSubscriptingAssignmentTrampoline.h */,
-				7057D8040E6E22620A32A1A4125D991C /* RACSubscriptingAssignmentTrampoline.m */,
-				A9A4E2B6F473FBB306154C442E6FD9AD /* RACSubscriptionScheduler.h */,
-				E6D3799F93F2F7A590C79FCB070DE22C /* RACSubscriptionScheduler.m */,
-				B9919FA09FC18EF187A3F988C6102903 /* RACTargetQueueScheduler.h */,
-				54C2599E17B9A70EDB8547A831B50BD0 /* RACTargetQueueScheduler.m */,
-				BE307B8FD7B5CA8DEA04A1D6F7F8AFB2 /* RACTestScheduler.h */,
-				C8CA520F048665D31F25988E787189B9 /* RACTestScheduler.m */,
-				B8EED562581C016F20A615D17793A422 /* RACTuple.h */,
-				7C31631E8EF0A85EEB6534D32B617F0E /* RACTuple.m */,
-				3059F2F2EBECE984FA730D95BCD35958 /* RACTupleSequence.h */,
-				5180C63571ACBAA2A7DB11B1A290A09A /* RACTupleSequence.m */,
-				8A5DD6C875E236D9328F2AF10B590C11 /* RACUnarySequence.h */,
-				3C8E5736DBD756980A7BABA839F5B636 /* RACUnarySequence.m */,
-				968B7628D7650F79B99757777F1F6B45 /* RACUnit.h */,
-				3D44EDB64D9F57A0D754B5B5012C1BC8 /* RACUnit.m */,
-				01E852CFF7297852B9ACBE5B41503CA2 /* RACValueTransformer.h */,
-				958D014BD521F902010219C7B9A93B0B /* RACValueTransformer.m */,
-				293C9029DA0B2225C8096D4A9AEE0949 /* RACmetamacros.h */,
-				A085138FD85799F258E9DFFDFBC4A51D /* ReactiveCocoa.h */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		CCA510CFBEA2D207524CDA0D73C3B561 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F9B82514055D19AB45D98F525AD88BC1 /* TUSafariActivity.bundle */,
-				EEE9FB22B588D60581B7BE13A5E1F720 /* libARChromeActivity.a */,
-				F077C8F8D77D4BE463481167448A3342 /* libPods-OSXDemo.a */,
-				A6ACADEDEECCBFAA57DE01838F58A4A2 /* libPods-OSXDemo-ReactiveCocoa.a */,
-				BF578BF5903DF1641C7DE12DBBB71B4A /* libPods-OSXDemo-ReactiveViewModel.a */,
-				233E2535C90C8FB3CA860678CFB12392 /* libPods-iOSDemo.a */,
-				DA24B7F885E15C578578B6BD2C5E7511 /* libPods-iOSDemo-ReactiveCocoa.a */,
-				A35FCD5B3D1F60E5A649F79BEC781AE1 /* libPods-iOSDemo-ReactiveViewModel.a */,
-				B99FD257E3984B895A80262D85173949 /* libTUSafariActivity.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		D1B887DA3785F4ADCD3D01DA1B3331EA /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				802D86B053D0806CC50539EDBD274D2F /* Pods-OSXDemo-ReactiveCocoa.xcconfig */,
-				71542763296C6D0C0B5E0CDF83B59F20 /* Pods-OSXDemo-ReactiveCocoa-Private.xcconfig */,
-				A06A3A96FB9D289AB191978F0589B50E /* Pods-OSXDemo-ReactiveCocoa-dummy.m */,
-				A1983C3667246C3F359BF258961CF349 /* Pods-OSXDemo-ReactiveCocoa-prefix.pch */,
-				4925BE2DEE3CF6BC8B4B368134717AD6 /* Pods-iOSDemo-ReactiveCocoa.xcconfig */,
-				E276A41B5D96BAB853B977C537E223C6 /* Pods-iOSDemo-ReactiveCocoa-Private.xcconfig */,
-				0EFF6773BDB5919C49059D46FFC988AA /* Pods-iOSDemo-ReactiveCocoa-dummy.m */,
-				F76D3B8FFE292C9B1D1235A38C3ABFE2 /* Pods-iOSDemo-ReactiveCocoa-prefix.pch */,
+				DD3A50687D01BB54B2123BCA4E847B64 /* Pods-iOSDemo-ReactiveCocoa.xcconfig */,
+				3FA8419CFF8317241C8B6B42B22AC7F2 /* Pods-iOSDemo-ReactiveCocoa-dummy.m */,
+				6612E321ECD0C38A0BE40D3334F84B26 /* Pods-iOSDemo-ReactiveCocoa-prefix.pch */,
+				0A405F68FB8ADD2325247C946DE6BBE2 /* Pods-OSXDemo-ReactiveCocoa.xcconfig */,
+				134BEB56A5F2B5C8F3FE83294F7AAF00 /* Pods-OSXDemo-ReactiveCocoa-dummy.m */,
+				D0B2C4966AD0CE47B90366DA75F06F87 /* Pods-OSXDemo-ReactiveCocoa-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-OSXDemo-ReactiveCocoa";
 			sourceTree = "<group>";
 		};
-		D6E342895E7A7DE591149630A68FA799 /* ARChromeActivity */ = {
+		8E27D259494053C335288F0326DB4D45 /* ARChromeActivity */ = {
 			isa = PBXGroup;
 			children = (
-				B6411D8038636F4B27F0FFFCA810C0D7 /* ARChromeActivity.h */,
-				8D59F02C5B74A313E1054FDB67DAC37E /* ARChromeActivity.m */,
-				3340C3EA59979AE222351EB81618E291 /* Resources */,
-				3C6DAA7AC704E24244A26D600ED0D0DA /* Support Files */,
+				6ABFEA83E3849B39372FF0DC51F84509 /* ARChromeActivity.h */,
+				E88E47ACC6EB670DBE4C1C53ADEC7D40 /* ARChromeActivity.m */,
+				3EACF04886108DD9873D5B1DCBC23E38 /* Resources */,
+				D1AA6BDB99655A8D77CCD86DEA74C4E0 /* Support Files */,
 			);
 			path = ARChromeActivity;
 			sourceTree = "<group>";
 		};
-		DD8B3F99C64FE593550BCEF9194A661A /* Support Files */ = {
+		9304B30CB87FDB77B6CEE9FB6B800855 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
-				954E95BFF007FAEDFAF7EC7483E90185 /* TUSafariActivity.xcconfig */,
-				5AC54F503BAFAE36F032D4A927FDA326 /* TUSafariActivity-Private.xcconfig */,
-				2F1B9802B73E4DA17207F8CD37A39FE5 /* TUSafariActivity-dummy.m */,
-				EB887DB01BF844A81142373B1A75608C /* TUSafariActivity-prefix.pch */,
+				DE25DD04263CA735DBC0065D686C708D /* Cocoa.framework */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/TUSafariActivity";
+			name = "OS X";
 			sourceTree = "<group>";
 		};
-		F74EA9E98B373D3D87F447B7875E8770 /* Support Files */ = {
+		9D00EA2FC3F4ADBADB491D2463A26012 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9D518B70F6A5858D0CB415A288D655EA /* Pods-OSXDemo-ReactiveViewModel.xcconfig */,
-				A56A315A07398300294330C778796CF8 /* Pods-OSXDemo-ReactiveViewModel-Private.xcconfig */,
-				BDA197270DE813CD77C9978D2DAEF369 /* Pods-OSXDemo-ReactiveViewModel-dummy.m */,
-				2EFC3934F752476FF141AEF6C78319B5 /* Pods-OSXDemo-ReactiveViewModel-prefix.pch */,
-				3F0D14CA1ACB0C7076B3F06E55591CBB /* Pods-iOSDemo-ReactiveViewModel.xcconfig */,
-				894CFD9649A3459DD133C375212142FA /* Pods-iOSDemo-ReactiveViewModel-Private.xcconfig */,
-				56B0F6DD87776B594048AEAE3FF2E706 /* Pods-iOSDemo-ReactiveViewModel-dummy.m */,
-				349E1FDED193C354EB8D67439599914A /* Pods-iOSDemo-ReactiveViewModel-prefix.pch */,
+				6875BC26EFDB0A1C55A6A9C5ECB3C160 /* libARChromeActivity.a */,
+				B507DBC4C240E2456A33DF9E4090574C /* libPods-iOSDemo.a */,
+				B0037FA89196A9C782176E61F86BF72A /* libPods-iOSDemo-ReactiveCocoa.a */,
+				6E3EF5B019FA0D87FDE0A2978F087E1E /* libPods-iOSDemo-ReactiveViewModel.a */,
+				033D56448351C3C2E66F95B8CDD8AD6C /* libPods-OSXDemo.a */,
+				05B7537A9C61D330D19940B358C327A8 /* libPods-OSXDemo-ReactiveCocoa.a */,
+				235C4CF7D2AFE8FCDC571771F68A2287 /* libPods-OSXDemo-ReactiveViewModel.a */,
+				967C40AB234F3FA17185F324D2037CBC /* libTUSafariActivity.a */,
+				39E3BE57B38E6B4994C83783F83AAC26 /* TUSafariActivity.bundle */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-OSXDemo-ReactiveViewModel";
+			name = Products;
 			sourceTree = "<group>";
 		};
-		F77D0F4758CA1A31EC1B3E9C12D78CB3 /* Resources */ = {
+		BA5AA96D77292F4B5C56879B2500DEB0 /* ReactiveCocoa */ = {
 			isa = PBXGroup;
 			children = (
-				F4ACFFD726DE98F952D2715A8FE904C3 /* cs.lproj */,
-				2EE58839D3A596AA8AD1E3C331D506F6 /* de.lproj */,
-				2CC01C0141A3E749870A67763348DF74 /* en.lproj */,
-				0DC326BC82862EFA1620E6C3A7E35213 /* es.lproj */,
-				20A5943D7F6A92BA8A48314327AB2516 /* eu.lproj */,
-				F23AAEFCF552C6430E5A77A17BF89206 /* fi.lproj */,
-				7EADC9D8C9636E0994AB340660AF1CAF /* fr.lproj */,
-				917C79F249E898193708DA61EFABDF27 /* it.lproj */,
-				C8B4E1B576455BF39FE0A5053F83000C /* ja.lproj */,
-				F37E0664305307657AFE92692D44B60E /* ko.lproj */,
-				2B3A51FA14C49CBAE314B9D403F44B23 /* nl.lproj */,
-				8971DC9D6EAB1D6AAAE39C537BC0AC23 /* no.lproj */,
-				2638C213F8CF918A737ABC1649BAAAD4 /* pl.lproj */,
-				53E2B0BCDB0E396BF7DDA641486794BB /* pt.lproj */,
-				FE850AFB1F3120138D61FDBE9B17A05E /* ru.lproj */,
-				138A1DABBD9576D0FDB48C429147149D /* safari.png */,
-				0514209F70FDB845FFBBB2BA42AB1B75 /* safari-7.png */,
-				3E73BADC9E8D63779CB79360C0F84B89 /* safari-7@2x.png */,
-				CD5382D0ACA18ABC23819294F2F32123 /* safari-7@3x.png */,
-				86645EB49F8FB75B21E8306B02878A72 /* safari-7~iPad.png */,
-				66766A6D1C81A945DAB83EFFA4EFCA16 /* safari-7~iPad@2x.png */,
-				81259BB9DD6807FF7905E6C94FC4D0C6 /* safari@2x.png */,
-				2AA16D46D4D749459B908DA762C0E8D1 /* safari@3x.png */,
-				D2F35B878B8E6E79BED2280C1749AEBB /* safari~iPad.png */,
-				B40B0208A1D16EA436C900B5E6834C9B /* safari~iPad@2x.png */,
-				49492D834246297A7CF98C30CEA2A556 /* sk.lproj */,
-				142369E5E72C70E19E4EB45CE716AA80 /* sv.lproj */,
-				317B69C1A94EF8A3DD04C4FB9AC87E33 /* vi.lproj */,
-				E098CE032BC1EAF0A0AB6A2E19EDE2D7 /* zh_CN.lproj */,
+				C216C51BB73898839E54E24B912F9CB7 /* Core */,
+				F38EC98E72A672121802BDE56AEAC73F /* no-arc */,
+				89CD5E48CCD0C0ADB32F4CD75922CC7A /* Support Files */,
+				46AD6515B2FE874D40F134FC4E7341E4 /* UI */,
 			);
-			name = Resources;
+			path = ReactiveCocoa;
+			sourceTree = "<group>";
+		};
+		C216C51BB73898839E54E24B912F9CB7 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				A329D816C2F2213778D9939A93331319 /* NSArray+RACSequenceAdditions.h */,
+				3A5C2149B8B2DEA7D2F2CAE26324D19A /* NSArray+RACSequenceAdditions.m */,
+				0E500123DAEA08E61707389A7FAFC1AA /* NSData+RACSupport.h */,
+				7D85CF475C2D1221735F4DF331143B05 /* NSData+RACSupport.m */,
+				6F4A160440A8B2FF8B2B6B06ACF1B684 /* NSDictionary+RACSequenceAdditions.h */,
+				3C44B31BD9267002FDCDD568489B54CC /* NSDictionary+RACSequenceAdditions.m */,
+				0F6254C71C0A178F4171511AEB8A9687 /* NSEnumerator+RACSequenceAdditions.h */,
+				AE27EA7CAEB8311B644CB85293D916DC /* NSEnumerator+RACSequenceAdditions.m */,
+				72C2B3C894F2A29A96B89D88A55E7CD9 /* NSFileHandle+RACSupport.h */,
+				120F3874772746C6F170DFF03207E670 /* NSFileHandle+RACSupport.m */,
+				F1428F11F9628EDD1139CDE89B8C90E9 /* NSIndexSet+RACSequenceAdditions.h */,
+				4959D6C84F130BAA503DC4E91BCC82AE /* NSIndexSet+RACSequenceAdditions.m */,
+				37002A63E9E6E4EEB785E3B7FC711688 /* NSInvocation+RACTypeParsing.h */,
+				C270D701D6F4B96200E26E366825A467 /* NSInvocation+RACTypeParsing.m */,
+				EB49F60CE74628B3C0C3D769AC9840E8 /* NSNotificationCenter+RACSupport.h */,
+				8779A4D42A5650CB95D2EEAC137124DF /* NSNotificationCenter+RACSupport.m */,
+				A2F96E2E97075D92AF666FCCA4554B75 /* NSObject+RACDeallocating.h */,
+				80ED1CA9F210442B0DD56FFA51B2C4AA /* NSObject+RACDeallocating.m */,
+				788F9FFC390C35226C2E91C9BA9CED2E /* NSObject+RACDescription.h */,
+				C644D1BF24A98CB98BCE2BBDE36C2CE6 /* NSObject+RACDescription.m */,
+				0F1E0A18E952AEC126E60CEA89612836 /* NSObject+RACKVOWrapper.h */,
+				37E1902C80D9EEB727A868597548E8B6 /* NSObject+RACKVOWrapper.m */,
+				4EE1F11172ACC84F9F93C132409F3805 /* NSObject+RACLifting.h */,
+				47481A10CF7489BC884AA7B2BDC03B9B /* NSObject+RACLifting.m */,
+				F1E4266053F0334195583B8507760C83 /* NSObject+RACPropertySubscribing.h */,
+				36270DE5D71EF8CBE60C877DA756B83D /* NSObject+RACPropertySubscribing.m */,
+				709639233E1017FC9678B5D70FFA2292 /* NSObject+RACSelectorSignal.h */,
+				274F15284CFB468B6CBCFD3F186474EB /* NSObject+RACSelectorSignal.m */,
+				7A882782481897DBA10857829DAD21EC /* NSOrderedSet+RACSequenceAdditions.h */,
+				D9AE86624AFC9C6FC61F9E6104120905 /* NSOrderedSet+RACSequenceAdditions.m */,
+				51B9DF2E8A5B92B847CBA70C6DCBA640 /* NSSet+RACSequenceAdditions.h */,
+				B8473348A056B38B0C59FE8AE7903883 /* NSSet+RACSequenceAdditions.m */,
+				70143DCDA08FD8511BBD162A689C9586 /* NSString+RACKeyPathUtilities.h */,
+				2E71ED0750C26510E6B897F643D5444F /* NSString+RACKeyPathUtilities.m */,
+				B534FDB920FAC79E1FA3600D98CA267B /* NSString+RACSequenceAdditions.h */,
+				BCF31D7931E616FC159ADC40EC2A01FB /* NSString+RACSequenceAdditions.m */,
+				36DABAAB01574F6D05556E05F1C7886B /* NSString+RACSupport.h */,
+				F7BD85416822118288CF55855BCC81E0 /* NSString+RACSupport.m */,
+				1EB0DCCD4C1074EC80B2BC2F21E19BDB /* NSURLConnection+RACSupport.h */,
+				BB1569555B56484A2A4EAC45E16C16E2 /* NSURLConnection+RACSupport.m */,
+				708E969B2907B623C2627AD4BDF1490B /* NSUserDefaults+RACSupport.h */,
+				83B887511BF2617ECE7C6484B30CE242 /* NSUserDefaults+RACSupport.m */,
+				98FA579B637755D52A4505EE262FDE9C /* RACArraySequence.h */,
+				E23C108CFAD47EF27DDF7E44E4FB8FB4 /* RACArraySequence.m */,
+				772F283003A8AC5412D5438B06671B09 /* RACBehaviorSubject.h */,
+				B7534CE72B041952F0E25B4B9013E05B /* RACBehaviorSubject.m */,
+				73C34C61A1F72050F3A764015E301663 /* RACBlockTrampoline.h */,
+				5BD3BE967CA3B8E13D6AECF19FB715BC /* RACBlockTrampoline.m */,
+				E1508103414BB7E14E8984399C9BC442 /* RACChannel.h */,
+				8E38002CD8A532CB3CE53B3D19C5ECBB /* RACChannel.m */,
+				FE8FE679B677A7E6F7086E8A464613C1 /* RACCommand.h */,
+				8BAECDC6199A01A2636394F6E19A7B26 /* RACCommand.m */,
+				3F43ED09C69D6993AB10E5D62CB456BF /* RACCompoundDisposable.h */,
+				45A10DA99BDBDB3EE7671A2C144E976D /* RACCompoundDisposable.m */,
+				4E5F4509ADD430EE8F89B85534EFBCB0 /* RACCompoundDisposableProvider.d */,
+				D71399581762FEF04A769C8B160762B4 /* RACDelegateProxy.h */,
+				CC39B61678940382A63A47C01EECD74E /* RACDelegateProxy.m */,
+				EABEDB0AE5F32B33577D0D53825DFA19 /* RACDisposable.h */,
+				BDF5E401159ACAADA85A671D0FCE1523 /* RACDisposable.m */,
+				893F8430F08B52DC3C96E556770EDA86 /* RACDynamicSequence.h */,
+				EDB801CEAA8D8921F02950E802201161 /* RACDynamicSequence.m */,
+				6EFE8403BF0117108A8BFA500FE993BB /* RACDynamicSignal.h */,
+				08B82EECBF8A1E3B1AC819C1AFC316C7 /* RACDynamicSignal.m */,
+				617968821460F8AC471D89413A9DF24C /* RACEagerSequence.h */,
+				6F542C0B6F81A99C228AE9560FD9F0F7 /* RACEagerSequence.m */,
+				F7481C5F920E60874D71CFA0D8E0DCC6 /* RACEmptySequence.h */,
+				8DD55019777DFDAA80710EF4DB635ACA /* RACEmptySequence.m */,
+				6F0044387D70A7AF1345FD32DEE471E9 /* RACEmptySignal.h */,
+				803DF260A9832F92820C5B289B315CBA /* RACEmptySignal.m */,
+				425CFFAA98530C1BFB112FCF22298B1E /* RACErrorSignal.h */,
+				A1076E7E636454F31CDE2099B7E3EF13 /* RACErrorSignal.m */,
+				97AB17BC5CF27F73DCBF21298655B330 /* RACEvent.h */,
+				F787BB2D65C142FF059BC79EEF0F70AA /* RACEvent.m */,
+				EA240B549245CD49151AF9293E74AB4C /* RACEXTKeyPathCoding.h */,
+				4166B67985E832129EAB15E88080B505 /* RACEXTRuntimeExtensions.h */,
+				A5E45E0ADD13BBAFF71F490835754362 /* RACEXTRuntimeExtensions.m */,
+				81E5065A81696C65B1CD15EE4BFB536C /* RACEXTScope.h */,
+				6AD0BF205524EC06E486E117887EB76F /* RACGroupedSignal.h */,
+				B9657F3E32D6D8BC4DD13373E4D008AE /* RACGroupedSignal.m */,
+				34347072E45C1C811C272F97F0329E38 /* RACImmediateScheduler.h */,
+				F503678C4EFDC52B004DCB1A0B228225 /* RACImmediateScheduler.m */,
+				9EF65483CD35392071676488A9E419E5 /* RACIndexSetSequence.h */,
+				70299A5BDF8CE735AF9FCD74373B9103 /* RACIndexSetSequence.m */,
+				AEFD11FFA22306403DAE6070F4AC59D1 /* RACKVOChannel.h */,
+				1CBDC8C527A7B2A185E69332AFC5DBBE /* RACKVOChannel.m */,
+				208B63F2B8CBA2F1604B2B19B90E445B /* RACKVOProxy.h */,
+				8AA256A6B86B8586CA6D817C9AA12774 /* RACKVOProxy.m */,
+				D0DF21578ECB4026776B790EB79B0C80 /* RACKVOTrampoline.h */,
+				570717F38B5F03275E96B390706F0523 /* RACKVOTrampoline.m */,
+				91777DD0DB90EF236040511559064993 /* RACmetamacros.h */,
+				7789BBD868C60E7E7C8FB7F6E06C2746 /* RACMulticastConnection.h */,
+				FEB312B74AB90A72954E8E689CE204A0 /* RACMulticastConnection.m */,
+				2BA5246E0C85D0A42C3812633DF39AA0 /* RACMulticastConnection+Private.h */,
+				679CF73E3F669DEF801D3B6A4A862F6F /* RACPassthroughSubscriber.h */,
+				6ED587E2C894A15AA5CDECB1B2B93917 /* RACPassthroughSubscriber.m */,
+				A834F93BC9FADB87774DBE6790BB8215 /* RACQueueScheduler.h */,
+				00F0C00101BEFE4054340A7FCC4B3BB4 /* RACQueueScheduler.m */,
+				F4784456047EB0648FEB43746056BB3C /* RACQueueScheduler+Subclass.h */,
+				469B9F12809631BD28D225E7F4BA9674 /* RACReplaySubject.h */,
+				28F138F237430279CE7919A3BDD76B19 /* RACReplaySubject.m */,
+				F527135FA232D5728A653C94B197011C /* RACReturnSignal.h */,
+				7CF788A90F5E2BE503F85BAFA227B0C7 /* RACReturnSignal.m */,
+				4510C24033F59D6991A5646B7E160400 /* RACScheduler.h */,
+				3CB11195D5A701B6AE3AF8056DA203F9 /* RACScheduler.m */,
+				6D3FF8FDA1F05D29CBFE75B9F886B2BC /* RACScheduler+Private.h */,
+				CE7669142BF7120C7E8A1AA719C5B424 /* RACScheduler+Subclass.h */,
+				B8A084193A9B5ECD4417960C9C0007A9 /* RACScopedDisposable.h */,
+				BDEC867AA813B628004E1B2ED75269AC /* RACScopedDisposable.m */,
+				EAB16CEA3E3AD133D8C5B60DFFF408D5 /* RACSequence.h */,
+				40B467B3D444CC69E160033689A75ECB /* RACSequence.m */,
+				47FEDFB3D989A901B9E35C29DA7460AB /* RACSerialDisposable.h */,
+				7F87D35AE7E8B8140FF1B365B76FFEFE /* RACSerialDisposable.m */,
+				2F5DAF475ABE18CD88FDB8CBC1F2FA40 /* RACSignal.h */,
+				A0EDD6B1D98AC2EACE5C1E4EAFEF3835 /* RACSignal.m */,
+				1210B1DF19548400A35244EA4F146E81 /* RACSignal+Operations.h */,
+				4137AF19338CEFF61DC82EB4691B439A /* RACSignal+Operations.m */,
+				FEB614E55CB1AE19C3A5916F1E2E356E /* RACSignalProvider.d */,
+				139AEEC6E450D1764DEE395F1D4C2150 /* RACSignalSequence.h */,
+				F9DA6CAE4C66DB6CE66E9E4C6F0C0D5C /* RACSignalSequence.m */,
+				A711C6C1895952B4A0ED343E892FE407 /* RACStream.h */,
+				752BABCDFA9B041845F7EDEB8439A73D /* RACStream.m */,
+				A1A52E0AF777D3E19A75BE97CDC841BA /* RACStream+Private.h */,
+				D7FC064031A4553160199635EEB0D18A /* RACStringSequence.h */,
+				5D53C9479EF64D8F6D8E622C5B32ED70 /* RACStringSequence.m */,
+				A1084B01A355A228A8CFBAD5F74F07DD /* RACSubject.h */,
+				34571FAB0B24C9F9D1B040892BF6E9F9 /* RACSubject.m */,
+				C16A43675F88CBA0E243ACA36D51FB62 /* RACSubscriber.h */,
+				07B794E2A62A1F6D18109105EFBC4D18 /* RACSubscriber.m */,
+				2B8030026D1265BF65763707A6A9D160 /* RACSubscriber+Private.h */,
+				E5D539C728EE32A13C34541DA04503F9 /* RACSubscriptingAssignmentTrampoline.h */,
+				DE5ACDEF043F65F7630EF75360218E17 /* RACSubscriptingAssignmentTrampoline.m */,
+				2080FEAFF9401C553E635EEF2BA98064 /* RACSubscriptionScheduler.h */,
+				C9A2B3C1F44E5EABFDD122B88637B8A3 /* RACSubscriptionScheduler.m */,
+				56AD67C3E2FE5FC35A973287A0969531 /* RACTargetQueueScheduler.h */,
+				AF9C976683A04BFFF0EF3AFF514C2CA4 /* RACTargetQueueScheduler.m */,
+				30602E100F44E87EA80F6063BD044256 /* RACTestScheduler.h */,
+				E5BE3BA2C5DC6C49534DE219797AC9E8 /* RACTestScheduler.m */,
+				7CB8658983C2CCC96CFE328B56A69896 /* RACTuple.h */,
+				4F63902A4D80BF8C416E9A4F486CCD98 /* RACTuple.m */,
+				E555809B31EE3F0C0862DF4E78868C98 /* RACTupleSequence.h */,
+				0F5482872801818DA8BC1667FDAB0EEF /* RACTupleSequence.m */,
+				5A42591629D201EFB7229A3E3725E0FE /* RACUnarySequence.h */,
+				87B69D4A64EACE4F90F282AE61E7C383 /* RACUnarySequence.m */,
+				F0CFDD7C1EEFDB41E352A8E4F761D74A /* RACUnit.h */,
+				165353D5E6DF0EC21E8045AD106CAC18 /* RACUnit.m */,
+				7E3FC49C4EAA62B3E70C4F598AD6CFB8 /* RACValueTransformer.h */,
+				DE3B00EE7862C7D20332E3A81671AC4E /* RACValueTransformer.m */,
+				F7F24E40BA83A51628B3EEC30C456918 /* ReactiveCocoa.h */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		D1AA6BDB99655A8D77CCD86DEA74C4E0 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E366FD03168029DA75C718E058A8EDC8 /* ARChromeActivity.xcconfig */,
+				2DB72C4ACA6F2BEC8BBE0132985108B3 /* ARChromeActivity-dummy.m */,
+				79CF12DF9F484817859E9440531ED693 /* ARChromeActivity-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/ARChromeActivity";
+			sourceTree = "<group>";
+		};
+		E4E62DD732FFA08D8A6EAB5F1F27C7C8 /* TUSafariActivity */ = {
+			isa = PBXGroup;
+			children = (
+				5A9634710AD8EC8474C3D2197D43156A /* TUSafariActivity.h */,
+				37204DA41C99B516A634F86B125B7502 /* TUSafariActivity.m */,
+				3646D0BBF7F88AE337C185CFE71A2916 /* Resources */,
+				3CD9CB59FBF96E613D56C11A1864633F /* Support Files */,
+			);
+			path = TUSafariActivity;
+			sourceTree = "<group>";
+		};
+		EDC66583BA861E1C0C521F9226134C10 /* Pods-iOSDemo */ = {
+			isa = PBXGroup;
+			children = (
+				E3797EE485CA838B44F5E6FF9659A771 /* Pods-iOSDemo-acknowledgements.markdown */,
+				2E273984E705D1D0DF8EA7EDB04937F7 /* Pods-iOSDemo-acknowledgements.plist */,
+				05C76AF045F8C94DBD00386FD0010E37 /* Pods-iOSDemo-dummy.m */,
+				C4A6ED5392E8883803FCFF5D04D5F8F0 /* Pods-iOSDemo-frameworks.sh */,
+				95FC426913338E8A26F80294D95579E6 /* Pods-iOSDemo-resources.sh */,
+				236BC9E5E8DB36DE30265798B9BAF73A /* Pods-iOSDemo.debug.xcconfig */,
+				E4D9DBFB608C04F750360D207CB52017 /* Pods-iOSDemo.release.xcconfig */,
+			);
+			name = "Pods-iOSDemo";
+			path = "Target Support Files/Pods-iOSDemo";
+			sourceTree = "<group>";
+		};
+		F38EC98E72A672121802BDE56AEAC73F /* no-arc */ = {
+			isa = PBXGroup;
+			children = (
+				0C293262DB77360836562A12A306721C /* RACObjCRuntime.h */,
+				DF2188EAFC7EB0F456C45A3154B00C15 /* RACObjCRuntime.m */,
+			);
+			name = "no-arc";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		381B89A514D92EE02B27EFEEF95F054F /* Headers */ = {
+		2F222249943276A96CE1AE42193F102D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2022C651EA871FF8155DE4A401D9D638 /* RVMViewModel.h in Headers */,
-				3456EBC6A9BAC672A7222FB6D1C97D48 /* ReactiveViewModel.h in Headers */,
+				1A2F652199094E601A31A268DCDEAEA9 /* MKAnnotationView+RACSignalSupport.h in Headers */,
+				52672DFA4AF82E2C8C0C75D006DAAA96 /* NSArray+RACSequenceAdditions.h in Headers */,
+				EB387BA4DD06083739E50AA3AC8EFACD /* NSData+RACSupport.h in Headers */,
+				1FA9C0A40D4FF4736CCB3D0B2836C24D /* NSDictionary+RACSequenceAdditions.h in Headers */,
+				E9CD006D925C33C347D435E51A5E50A0 /* NSEnumerator+RACSequenceAdditions.h in Headers */,
+				86EE27A19598FD8515CFFB58FEAD2CF9 /* NSFileHandle+RACSupport.h in Headers */,
+				C5DBF7D198A1F15B381CAC16F0C1DCD7 /* NSIndexSet+RACSequenceAdditions.h in Headers */,
+				793501298714F847860A6CD498E729ED /* NSInvocation+RACTypeParsing.h in Headers */,
+				7FE2E0D0E82E28DA64D5CDBAF528553E /* NSNotificationCenter+RACSupport.h in Headers */,
+				6FCD6B71D38096BC9205F88AF8C3DD29 /* NSObject+RACDeallocating.h in Headers */,
+				7A78A8C58C53F012158B79DE82457860 /* NSObject+RACDescription.h in Headers */,
+				E610BCD2A45A0D5016D11B75AC84F90C /* NSObject+RACKVOWrapper.h in Headers */,
+				8B0F95EA52E02D1EF08DA47D4A708561 /* NSObject+RACLifting.h in Headers */,
+				FA06E3C02AAD83069C5847EE253F7D43 /* NSObject+RACPropertySubscribing.h in Headers */,
+				063A8C8A125507FA74A196DEF4845D2F /* NSObject+RACSelectorSignal.h in Headers */,
+				F2ECE30114F13927C9B6F3DCD0BE60B2 /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
+				F1A48BA97DE2ACF896DE0045A45B85BE /* NSSet+RACSequenceAdditions.h in Headers */,
+				88DF0225129E7709EC10CD85352D6D75 /* NSString+RACKeyPathUtilities.h in Headers */,
+				74B549D9A139C4C992D3AE368AA686B3 /* NSString+RACSequenceAdditions.h in Headers */,
+				5A9A70399E907CE4EF55EBC0DB36859D /* NSString+RACSupport.h in Headers */,
+				7513C8D08368F57F360BE24D54F61FE6 /* NSURLConnection+RACSupport.h in Headers */,
+				64507DB76C8C283F604D988FF7E08C36 /* NSUserDefaults+RACSupport.h in Headers */,
+				D517916C7433972084CA9BBC356D151A /* RACArraySequence.h in Headers */,
+				EAC98EB9D57F3C089B40B380EA5DDDB6 /* RACBehaviorSubject.h in Headers */,
+				C69BDA5B5D9FECB6BF8F692F1F56AD43 /* RACBlockTrampoline.h in Headers */,
+				2EF7C178A086C87A3D429AE1A8311499 /* RACChannel.h in Headers */,
+				10CDDC5A0AED376486AB1D2E649FA544 /* RACCommand.h in Headers */,
+				BC5352A3D9ED2C58E484D305E6D45EA7 /* RACCompoundDisposable.h in Headers */,
+				D701F444A0E18344179161E3B63C11BE /* RACDelegateProxy.h in Headers */,
+				5A496EB5ED04C71A817DE3A5A85980EC /* RACDisposable.h in Headers */,
+				D6E0AAC059597717DFDFB1802E666263 /* RACDynamicSequence.h in Headers */,
+				C3DEAC1AFAE6733E1B0ACB91E9EB4320 /* RACDynamicSignal.h in Headers */,
+				08B7A4E3A4B8BC1969A08F7A730443A2 /* RACEagerSequence.h in Headers */,
+				94AB962215B9005460BA0BB5B73805A4 /* RACEmptySequence.h in Headers */,
+				24CF86B96F6D3C307C99ECED886427E7 /* RACEmptySignal.h in Headers */,
+				041545D81916E3127A24D121CE29A4A2 /* RACErrorSignal.h in Headers */,
+				05BA564B7980A8207B2ED73134FCFD6D /* RACEvent.h in Headers */,
+				9416B6D659EFC3AF96CF2C63E2FA2068 /* RACEXTKeyPathCoding.h in Headers */,
+				B959F0E72E0DEAA4D67A0731CEB7E58E /* RACEXTRuntimeExtensions.h in Headers */,
+				5ADFEB280167A08892B0A853340F511F /* RACEXTScope.h in Headers */,
+				29195FC3DDCD37E3345A93CE67170A0A /* RACGroupedSignal.h in Headers */,
+				77A6997878051D462333592E477916D4 /* RACImmediateScheduler.h in Headers */,
+				8507B15A1ACC79F84C5422C967D000FB /* RACIndexSetSequence.h in Headers */,
+				54C3C04EECF005EA58004BEB1196CA7F /* RACKVOChannel.h in Headers */,
+				C13F64A9F966077BFA4A39BEAD1F05D3 /* RACKVOProxy.h in Headers */,
+				45C6AFA5A87086475D9BAED8FC38D7A1 /* RACKVOTrampoline.h in Headers */,
+				3E72C7622BBBDA150CE66A01C071B715 /* RACmetamacros.h in Headers */,
+				B1997F077B15FB68A7BD81F303DF7AB3 /* RACMulticastConnection+Private.h in Headers */,
+				9C9D0ABF36F90EA40B9DA9A206EB6911 /* RACMulticastConnection.h in Headers */,
+				577BF8386F9D8B0A83F9160B37AF806D /* RACObjCRuntime.h in Headers */,
+				7129EEACAC89145051060CB4C23799CF /* RACPassthroughSubscriber.h in Headers */,
+				5C09BC98C78E31EC43F5F2236AC4B973 /* RACQueueScheduler+Subclass.h in Headers */,
+				AA1086BC57E88D2EA40054C5C51FAC19 /* RACQueueScheduler.h in Headers */,
+				B81FF2E808C907F2593C219E7B2BCCFE /* RACReplaySubject.h in Headers */,
+				2B76C1709D705CFD4F9C1D5BB68412EC /* RACReturnSignal.h in Headers */,
+				E42F05B433FBACA37A9FC504A4F494B6 /* RACScheduler+Private.h in Headers */,
+				DAACCA291A89F6C1EA9E149BDFADBBF3 /* RACScheduler+Subclass.h in Headers */,
+				3815C341EC806260364620B03A8F7353 /* RACScheduler.h in Headers */,
+				482F25F898C40949E88BC180285A7031 /* RACScopedDisposable.h in Headers */,
+				626035FCF89FEFB6D97F36C47DD94FC0 /* RACSequence.h in Headers */,
+				27C150EF073A8A7E236D1BB43EBBC072 /* RACSerialDisposable.h in Headers */,
+				379C7C85C71305ABDDF192A7E4A8D955 /* RACSignal+Operations.h in Headers */,
+				65E2B6635B4681279BCCCE506102A124 /* RACSignal.h in Headers */,
+				2A55E0E41912005FFC148F9D0EC16B50 /* RACSignalSequence.h in Headers */,
+				D6F7A62FE4F0FDB5A9127E35A84FABB4 /* RACStream+Private.h in Headers */,
+				2281CD54778EF4A840BBDFD0830372BC /* RACStream.h in Headers */,
+				565AF73D422CD48D221158FB2A89F3B5 /* RACStringSequence.h in Headers */,
+				A7363E4D2FFF772428A2C69FED796213 /* RACSubject.h in Headers */,
+				BBA3BAD47ED2555CAF648659FE56ED04 /* RACSubscriber+Private.h in Headers */,
+				6C401876A716A112B1345423DDA2E63D /* RACSubscriber.h in Headers */,
+				8B702390C0974DF4ACC0931B7828C928 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
+				A318D19D5B6F22A21D66FCE750F0E343 /* RACSubscriptionScheduler.h in Headers */,
+				F22951D4303A68D7A398B2A77A4E741D /* RACTargetQueueScheduler.h in Headers */,
+				5349AE77739AF8494A145AB8C436DC98 /* RACTestScheduler.h in Headers */,
+				B800F2CFDDDF6FEE369E7E619A39D330 /* RACTuple.h in Headers */,
+				6B6E7C41414CFF79E741AC825223615D /* RACTupleSequence.h in Headers */,
+				1169746444DC0CFE6EAE759113ADE83C /* RACUnarySequence.h in Headers */,
+				7708359B41BDDBEF66E7E3D3A0398920 /* RACUnit.h in Headers */,
+				2DBC70A5144157CA7F11350C2F9E1976 /* RACValueTransformer.h in Headers */,
+				5C373EC207F0D353129CDBB9B8B291C1 /* ReactiveCocoa.h in Headers */,
+				93A5C133890E05899FFC5E5C78991340 /* UIActionSheet+RACSignalSupport.h in Headers */,
+				5AE6FEA9EA3F8286274C6B4A86B85729 /* UIAlertView+RACSignalSupport.h in Headers */,
+				3739435742EBA3C2D16A0572A1926620 /* UIBarButtonItem+RACCommandSupport.h in Headers */,
+				B45AD8C13C3912FB0B2FEF2FFB7DF862 /* UIButton+RACCommandSupport.h in Headers */,
+				70DA3A4BBAE30160387F5DA4EAB9F84C /* UICollectionReusableView+RACSignalSupport.h in Headers */,
+				288A103C2AA2BEB68308475F7CC30328 /* UIControl+RACSignalSupport.h in Headers */,
+				4B330C043CE4BE16BFCC3B9FC294D63D /* UIControl+RACSignalSupportPrivate.h in Headers */,
+				21B8AE9423C113CB4F62679F7BFACB99 /* UIDatePicker+RACSignalSupport.h in Headers */,
+				DA41323E9B1A7FE8028C3B50254D53E7 /* UIGestureRecognizer+RACSignalSupport.h in Headers */,
+				0D24F2CA17585B61583E401CB328555B /* UIImagePickerController+RACSignalSupport.h in Headers */,
+				1CEAC508AB0142AF1085EB60C742B963 /* UIRefreshControl+RACCommandSupport.h in Headers */,
+				29ABECD0C0238A5D6A2EE7700785F487 /* UISegmentedControl+RACSignalSupport.h in Headers */,
+				754D0ACA8F4FD9C57B9B3DA080E162E8 /* UISlider+RACSignalSupport.h in Headers */,
+				B1D81460206CDDFD614C027BB02DD76E /* UIStepper+RACSignalSupport.h in Headers */,
+				F30A2AD28FF7BDD600A944B25BE9E6EF /* UISwitch+RACSignalSupport.h in Headers */,
+				F7A5383B73EE8A88C5AFCB163B349753 /* UITableViewCell+RACSignalSupport.h in Headers */,
+				93359A8D712A3D6A4E3AD81ECF567BA6 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */,
+				7DCE5060BEE96816EDAD4D4A54EAF187 /* UITextField+RACSignalSupport.h in Headers */,
+				0054563BECE53687979682A26062D839 /* UITextView+RACSignalSupport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		810B4C723C166D86DA8F12BA63F8EF0F /* Headers */ = {
+		3B0AFFC7D72150A1C1412BF442A41187 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CACFCC5E22C6D22263860902E0E9A481 /* NSArray+RACSequenceAdditions.h in Headers */,
-				6CB05727FB2BE08C0E1D76835750FF8C /* NSControl+RACCommandSupport.h in Headers */,
-				82D6099BC1B35DC92EE2662633E4CEFE /* NSControl+RACTextSignalSupport.h in Headers */,
-				85F44CD4CB38F89998891334482D78F6 /* NSData+RACSupport.h in Headers */,
-				DE116BE715A8223321B5CECEF6572CE0 /* NSDictionary+RACSequenceAdditions.h in Headers */,
-				ECE9E3CA4B700D4B62934DEA5F0BCC1C /* NSEnumerator+RACSequenceAdditions.h in Headers */,
-				2A80214D1D0E013ACC9CD4E623DEA431 /* NSFileHandle+RACSupport.h in Headers */,
-				B2F1F82197273DAD5B02A643A23588AC /* NSIndexSet+RACSequenceAdditions.h in Headers */,
-				665228B606AC8A081AFD45F85A352095 /* NSInvocation+RACTypeParsing.h in Headers */,
-				B2AC038BFB8B570773E3AE00A246F736 /* NSNotificationCenter+RACSupport.h in Headers */,
-				403223EC2378D663121C376E1AC3D088 /* NSObject+RACAppKitBindings.h in Headers */,
-				5B19E9F553D40A4387E9C712BC46680A /* NSObject+RACDeallocating.h in Headers */,
-				1DE7A04A4EBFE8B57BF175C52BA7E1EF /* NSObject+RACDescription.h in Headers */,
-				984580B34E1D361D38E786B726B363F0 /* NSObject+RACKVOWrapper.h in Headers */,
-				D30F2A8DAF43D8053FA7E6BE5408EF92 /* NSObject+RACLifting.h in Headers */,
-				AB3873104821F25BA0C8EADB50843B85 /* NSObject+RACPropertySubscribing.h in Headers */,
-				368688BC2E9E45C3FDEC0D6E33491588 /* NSObject+RACSelectorSignal.h in Headers */,
-				4A34CDAE3007A4C3DF47874C1FDE128A /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
-				F2150743B0677F0655DB36B820A007A6 /* NSSet+RACSequenceAdditions.h in Headers */,
-				C92E9058DA17C47D7CF947000356349D /* NSString+RACKeyPathUtilities.h in Headers */,
-				971E6122F7390754E84C6E29EE13F44B /* NSString+RACSequenceAdditions.h in Headers */,
-				C2F2BB5F291AF0A0C7DD2D3427245374 /* NSString+RACSupport.h in Headers */,
-				3F98BAF69199D79F3CAA177C178E42A3 /* NSText+RACSignalSupport.h in Headers */,
-				085490258D028398D7FA1D1346F31C7F /* NSURLConnection+RACSupport.h in Headers */,
-				59360E9F2C848D894D421C10A7FEDDCC /* NSUserDefaults+RACSupport.h in Headers */,
-				139854AB689B7024C8FAA8AAB567C5AC /* RACArraySequence.h in Headers */,
-				202F41BCA2FFE27D2A0EA595BF41BD30 /* RACBehaviorSubject.h in Headers */,
-				A93A50967991F1B591481C48349BEA25 /* RACBlockTrampoline.h in Headers */,
-				E8826EBCD866C86241B0E2725615798A /* RACChannel.h in Headers */,
-				04D2B3A528963CBBF353E071BCE6996C /* RACCommand.h in Headers */,
-				829A03BA36217086818BC4440F3095BE /* RACCompoundDisposable.h in Headers */,
-				FCE3535857F5A9727FE6F3FF085A8F72 /* RACDelegateProxy.h in Headers */,
-				C2EE1B133983B3924285B7C892C99604 /* RACDisposable.h in Headers */,
-				FF6D4EA9855CF8927AB7B5A196B5F632 /* RACDynamicSequence.h in Headers */,
-				0DAC6F0A835F604FBD73D9BC6951590E /* RACDynamicSignal.h in Headers */,
-				61537EE153DE1B933FCB2C554B3A51D7 /* RACEXTKeyPathCoding.h in Headers */,
-				58DC920E152FCEC9877C0B09B7118A76 /* RACEXTRuntimeExtensions.h in Headers */,
-				C403206ECB36613696634981FA5CABA8 /* RACEXTScope.h in Headers */,
-				156CBC7A968E340E4AA8BBCFDCFAB341 /* RACEagerSequence.h in Headers */,
-				E5FD189A074EAE11ABFDE8D6AA6BDCF1 /* RACEmptySequence.h in Headers */,
-				6C2F36A14C0763502BE3E64D3FBF2C65 /* RACEmptySignal.h in Headers */,
-				C65C85058D4BBBE6459AF09D0686C225 /* RACErrorSignal.h in Headers */,
-				0812DE60AFE743FD4D9221362821EFFC /* RACEvent.h in Headers */,
-				502AB5C7F4D7F1F4A3AFB9AA211C89BD /* RACGroupedSignal.h in Headers */,
-				963D1D4CE575F7DF1EED85570ABB9EC8 /* RACImmediateScheduler.h in Headers */,
-				0F506DBB2534ECBFF1CEC2CAFC8ED23E /* RACIndexSetSequence.h in Headers */,
-				8EF4F113DA7EA4EFB309A886408709BD /* RACKVOChannel.h in Headers */,
-				A15B4EA76D7F4A845BE387F89AA246EC /* RACKVOProxy.h in Headers */,
-				B6287869B8933BA3B736BC0BAE908FFA /* RACKVOTrampoline.h in Headers */,
-				7ECD272EC3D16EDF624708D777557B66 /* RACMulticastConnection+Private.h in Headers */,
-				45BEC210EF759751A63751FDEE440C42 /* RACMulticastConnection.h in Headers */,
-				3F8143B1D72FCCEA91F6D1CE52910960 /* RACObjCRuntime.h in Headers */,
-				08493C44CD3B53AAAAFFAB5BF695967F /* RACPassthroughSubscriber.h in Headers */,
-				766A04896B6B9CBD04F8D1B4C412213D /* RACQueueScheduler+Subclass.h in Headers */,
-				57D2CC7CF91AD6BD2B0E503DBB5C2D2D /* RACQueueScheduler.h in Headers */,
-				A71D21CFDEFA68989CFFD9426D642506 /* RACReplaySubject.h in Headers */,
-				00A60D23DD18B92CB6702BED01DDBD5B /* RACReturnSignal.h in Headers */,
-				78B41F2EB6656B1ADCC3A41C2DF542F5 /* RACScheduler+Private.h in Headers */,
-				21478D2D5245EAC70F783C82CBF835DB /* RACScheduler+Subclass.h in Headers */,
-				337A04D7DA99DB2B7084AAA7EEC3E0F8 /* RACScheduler.h in Headers */,
-				E5C346A98DA2EEDAB3022FAF40CDE944 /* RACScopedDisposable.h in Headers */,
-				734F81C14662936D563F4F434CD0AEA6 /* RACSequence.h in Headers */,
-				1A60EB03B74474473232CD8651DE4B68 /* RACSerialDisposable.h in Headers */,
-				EA882855D24A42656BC9E00143F110AB /* RACSignal+Operations.h in Headers */,
-				57D4556B5A226EAD075D8BD52DF5BC3E /* RACSignal.h in Headers */,
-				03229CB5C2C53B2EB0CB789B59786652 /* RACSignalSequence.h in Headers */,
-				ADD80F2E8E93EB481C2DDB245E47A32E /* RACStream+Private.h in Headers */,
-				59205438CFA54DFBD538213AFD769C1A /* RACStream.h in Headers */,
-				B4C2FFD73393B8C1260A3034A478CFD1 /* RACStringSequence.h in Headers */,
-				F4791343A5F49F0A2BDD342D9F8711DE /* RACSubject.h in Headers */,
-				823475E8574289913CE5A2D88EE7F69A /* RACSubscriber+Private.h in Headers */,
-				FC41C5E3FE258CE62356EB1406DF1C28 /* RACSubscriber.h in Headers */,
-				8289878B1171A0100814DC1537DA6C4F /* RACSubscriptingAssignmentTrampoline.h in Headers */,
-				7D5DCB21E92772BED46E263A07A08B94 /* RACSubscriptionScheduler.h in Headers */,
-				D05B15062D6EC62434415D39EAD941BA /* RACTargetQueueScheduler.h in Headers */,
-				0E0D9022F975459DB38FB5B26155FEC1 /* RACTestScheduler.h in Headers */,
-				BE5E746F53EF357AF3AE84F3346F8FF4 /* RACTuple.h in Headers */,
-				5600C7479571AEF4E8A7D6A2357127A2 /* RACTupleSequence.h in Headers */,
-				FE63DE280C4EBB32FF37F122FF462C7A /* RACUnarySequence.h in Headers */,
-				1817DAFDD651DF1D5C17EA1964241372 /* RACUnit.h in Headers */,
-				5E247D85EF76F3EA6216A0816180D0CF /* RACValueTransformer.h in Headers */,
-				558ACB4B737AD26BD593B2CFC8836B30 /* RACmetamacros.h in Headers */,
-				23ABDB746DDD50DC288252B251985F1A /* ReactiveCocoa.h in Headers */,
+				6B27277BE87F50FC8C08FED6487C3129 /* ReactiveViewModel.h in Headers */,
+				4FCD1BC0A3015951A12871F6810A0569 /* RVMViewModel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9D1BD6FAECC44155792A830FE1B8AD8F /* Headers */ = {
+		9E5D254E124F7DC163207B83F490091D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DFA1EB0D313655F58AB1A785831818F9 /* ARChromeActivity.h in Headers */,
+				89C78591551DD57AED2B26C601DBF01D /* TUSafariActivity.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B6E8B871FF480C9AD26CB996753B5ACA /* Headers */ = {
+		A0BCA820D910F3F76D85C73E5FB7DEBA /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2D16FE43A7E0CD71D2F3120A370200A3 /* MKAnnotationView+RACSignalSupport.h in Headers */,
-				0406D48DB4A2C3AA271FE466CA4390C0 /* NSArray+RACSequenceAdditions.h in Headers */,
-				59EA3B5F4771927A62DA8444AA9148C6 /* NSData+RACSupport.h in Headers */,
-				B6F407C2288F4FFEC08DEC2B4CDF2A99 /* NSDictionary+RACSequenceAdditions.h in Headers */,
-				BC9D7EA2C9BB609F3A8531E646E74D9D /* NSEnumerator+RACSequenceAdditions.h in Headers */,
-				0E49B00B524211E7FFC2DEE991B5D85D /* NSFileHandle+RACSupport.h in Headers */,
-				866E794287AE79890D07FEBD6B69DB58 /* NSIndexSet+RACSequenceAdditions.h in Headers */,
-				B0B5BD38DA80F741CF970FE9D851DC3F /* NSInvocation+RACTypeParsing.h in Headers */,
-				26D2B6F2423C1D9C1858201D01EE5F10 /* NSNotificationCenter+RACSupport.h in Headers */,
-				64AC1BAC5E63902EA5970C58B60E2A3F /* NSObject+RACDeallocating.h in Headers */,
-				784084870DBA84549B3E67EA95E62C5E /* NSObject+RACDescription.h in Headers */,
-				9511BCB9002D4284E6D5A1A5373684DA /* NSObject+RACKVOWrapper.h in Headers */,
-				67B678D7C3A6217D6C6CB871BE13EDF7 /* NSObject+RACLifting.h in Headers */,
-				23DD70C69DCF4E4AEAE439D8F6C32255 /* NSObject+RACPropertySubscribing.h in Headers */,
-				18CD0EBD79A3F0F0131DBC06F7EE77B9 /* NSObject+RACSelectorSignal.h in Headers */,
-				566C1171A33AEE996DB4464D59073E99 /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
-				35F467AA9DCBEB04B93864B269939385 /* NSSet+RACSequenceAdditions.h in Headers */,
-				1B3C66DD2409D47E29ECF2342CE92112 /* NSString+RACKeyPathUtilities.h in Headers */,
-				5201CA441C97B17FC769E9534D1C4FE9 /* NSString+RACSequenceAdditions.h in Headers */,
-				186474497E80C27973F941FB7C13AB4D /* NSString+RACSupport.h in Headers */,
-				6F38E0ACA3D75CFCB2F7D6A027C61D09 /* NSURLConnection+RACSupport.h in Headers */,
-				9864D9AD767819D076CAE3B737291F61 /* NSUserDefaults+RACSupport.h in Headers */,
-				3CAFA3851C6C5F9F530A20AB4775D198 /* RACArraySequence.h in Headers */,
-				6B7D8418D8B55752964991AB9E5B7B3D /* RACBehaviorSubject.h in Headers */,
-				7374554BB665EC3CCDE8506DC4EA0779 /* RACBlockTrampoline.h in Headers */,
-				6432ABC2E70B87561FCEF4365B926777 /* RACChannel.h in Headers */,
-				D9DF45E4CFADE4215DBD963759E8A88D /* RACCommand.h in Headers */,
-				CBC4DA6DC2D7336D352E8A3ED4532581 /* RACCompoundDisposable.h in Headers */,
-				2308F61C2E899A81D07E5B2C16800628 /* RACDelegateProxy.h in Headers */,
-				D4474BA95B4F27C3BB8B2F3FC980BF1D /* RACDisposable.h in Headers */,
-				129F77160FF76AED71D15A0753DB6639 /* RACDynamicSequence.h in Headers */,
-				431CDBBF65B533BE1B6E03DBB5709430 /* RACDynamicSignal.h in Headers */,
-				C31303999473485CB4C1889841B0AC95 /* RACEXTKeyPathCoding.h in Headers */,
-				0C8E11ABB9306813B96CDDA1D830EAC6 /* RACEXTRuntimeExtensions.h in Headers */,
-				5A442B61AA317A209D7AD157ED3AD064 /* RACEXTScope.h in Headers */,
-				DDE1387E5E0954505C499A85508E2374 /* RACEagerSequence.h in Headers */,
-				2EE06B881C7DAD4A68ADD633178D7363 /* RACEmptySequence.h in Headers */,
-				97144CBDCBF24BB8AFE2A6FEF9F6CE74 /* RACEmptySignal.h in Headers */,
-				776CD064D02C6FDE953B12402CEAE2B9 /* RACErrorSignal.h in Headers */,
-				15231E6535E8B5B5FD9DFB99540F2ECE /* RACEvent.h in Headers */,
-				C4E42A26D5A8809612C050D1A1C95B03 /* RACGroupedSignal.h in Headers */,
-				057B5F18B203575407BA161D447513AA /* RACImmediateScheduler.h in Headers */,
-				E6B30429146096C2DEECB96B7DAA914F /* RACIndexSetSequence.h in Headers */,
-				4B1149024DAE066B4D85CC1C138A3C28 /* RACKVOChannel.h in Headers */,
-				15A015A69850625D94534D99790C2329 /* RACKVOProxy.h in Headers */,
-				1BD617F3151D5BE63C36E2065F88D9EE /* RACKVOTrampoline.h in Headers */,
-				2337603C2E329819AA8015A1622EF2FF /* RACMulticastConnection+Private.h in Headers */,
-				904AECD6E46F1606E9355F0EBBEE89CB /* RACMulticastConnection.h in Headers */,
-				8727109DCE6355A2DB820477358956D3 /* RACObjCRuntime.h in Headers */,
-				74689BFD73699C0FC0D352BF738F2D14 /* RACPassthroughSubscriber.h in Headers */,
-				187ABCD95B74B2E3E5206C8087317665 /* RACQueueScheduler+Subclass.h in Headers */,
-				7D01D534CB92D79878192D9F734F0881 /* RACQueueScheduler.h in Headers */,
-				43E08FF1C4B455FD6D5A8E5FBD5625DC /* RACReplaySubject.h in Headers */,
-				D628C3A73116FD49317FFFF7C0C6411B /* RACReturnSignal.h in Headers */,
-				4A2CF3158F9AFAF457058A3A394E2EEE /* RACScheduler+Private.h in Headers */,
-				548994209D74FAF2D7DBDF70C31226AA /* RACScheduler+Subclass.h in Headers */,
-				66EDD672FE974B3900B6AE9380DA3503 /* RACScheduler.h in Headers */,
-				707A37736BF00CEF31D572183BE7A32C /* RACScopedDisposable.h in Headers */,
-				880D15B375B3B6F260CAC870A88E7F84 /* RACSequence.h in Headers */,
-				83C3370A6598B30A43E29704588C0771 /* RACSerialDisposable.h in Headers */,
-				E18C5220051DBD13D1228C8D9DC69BAA /* RACSignal+Operations.h in Headers */,
-				672D443E574E3ACA073A29435FC37125 /* RACSignal.h in Headers */,
-				CB4465476C2B51D2D300D1589CC97E50 /* RACSignalSequence.h in Headers */,
-				22590A5E851520C7BD812BAF53A1BA47 /* RACStream+Private.h in Headers */,
-				2F16045AABBA3D96BC4865FB94381EDF /* RACStream.h in Headers */,
-				95940732B05B192087C25387E4768309 /* RACStringSequence.h in Headers */,
-				8D885CD777E0FFC71E7EF0DDD5C25F7A /* RACSubject.h in Headers */,
-				01C029CC1F03DB783D25DCD3A38DC9DB /* RACSubscriber+Private.h in Headers */,
-				603A6F2AD8463DD5A8AB4F3A817C06D4 /* RACSubscriber.h in Headers */,
-				A52122DB4216D6D4525FBCFAA88105E4 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
-				390378F7FDAFBDC8D488435761C82982 /* RACSubscriptionScheduler.h in Headers */,
-				DD36AC2518D5ADF1D3686F32774E80FA /* RACTargetQueueScheduler.h in Headers */,
-				92A82669DD165A87EE36F0EDAAA3B8C6 /* RACTestScheduler.h in Headers */,
-				E56F45D27E1B6BAE156119CC2884C500 /* RACTuple.h in Headers */,
-				9341656E020859732F1B50384ABA6043 /* RACTupleSequence.h in Headers */,
-				BB0AB72535E3A565B6AAE1F42C463673 /* RACUnarySequence.h in Headers */,
-				8587AC50F1FB7BCB3164A975D6CEE2DB /* RACUnit.h in Headers */,
-				72D1F3B119F627A080C0C594967963DB /* RACValueTransformer.h in Headers */,
-				353047E3787B39E04953351A446E5F89 /* RACmetamacros.h in Headers */,
-				C627DA54DCC6B160BA9C3BDBA04BD379 /* ReactiveCocoa.h in Headers */,
-				01BC9B6D15F61B7F3DB7234D3913CE0D /* UIActionSheet+RACSignalSupport.h in Headers */,
-				10BC88C39BEC4900A7DBD10A51B638B9 /* UIAlertView+RACSignalSupport.h in Headers */,
-				DD390F41741FA4BBD4A7E96C3E641D01 /* UIBarButtonItem+RACCommandSupport.h in Headers */,
-				AFA47FEFC8BE34D16C061A9F202D07C5 /* UIButton+RACCommandSupport.h in Headers */,
-				6415BB2C3C56A0BFA1B6BFB1081F3AFC /* UICollectionReusableView+RACSignalSupport.h in Headers */,
-				2705564EB9AC9D2D28B27EB45CC3BCA8 /* UIControl+RACSignalSupport.h in Headers */,
-				A127ADC6C5B2804648CC319B37150750 /* UIControl+RACSignalSupportPrivate.h in Headers */,
-				1F136FD3CE74BA6DD4D4A6A1B325B1F5 /* UIDatePicker+RACSignalSupport.h in Headers */,
-				CE671A84CA5EEE5ADAFC3B7E2D53F470 /* UIGestureRecognizer+RACSignalSupport.h in Headers */,
-				F1DAB34BAE13BC6AF2E8BC69FB97D83F /* UIImagePickerController+RACSignalSupport.h in Headers */,
-				839DCF276758CECC61663FC7EED52811 /* UIRefreshControl+RACCommandSupport.h in Headers */,
-				791B8CD50DC9EDB2AE033570BFA0B99C /* UISegmentedControl+RACSignalSupport.h in Headers */,
-				2FAF50D2DED11CE239E00AC3A0212F1E /* UISlider+RACSignalSupport.h in Headers */,
-				F550E3ED05A826A5A9C4FE790737F66C /* UIStepper+RACSignalSupport.h in Headers */,
-				9707BA6E5F087ECDFDEAA73F08DAA857 /* UISwitch+RACSignalSupport.h in Headers */,
-				86AD0BD722B5476F5C58047DA9519D47 /* UITableViewCell+RACSignalSupport.h in Headers */,
-				415F2DB36E839CC8D6FEA9C313C2A086 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */,
-				F3E234812FD4E9062A09DB4A298A44B0 /* UITextField+RACSignalSupport.h in Headers */,
-				54C739CF8556F30D05403B6E2165DB39 /* UITextView+RACSignalSupport.h in Headers */,
+				28BFD228FCB04083C816B81FE1A35D20 /* NSArray+RACSequenceAdditions.h in Headers */,
+				1863DF7E62D1D88D72D4A5134BA28FF8 /* NSControl+RACCommandSupport.h in Headers */,
+				EBCAF61C1CDB186E0D11A80B6DF0F772 /* NSControl+RACTextSignalSupport.h in Headers */,
+				129E9504478EC529D4C5AFC24D57A94B /* NSData+RACSupport.h in Headers */,
+				6A9529C81F3AFFFBD3C4915588D7EA73 /* NSDictionary+RACSequenceAdditions.h in Headers */,
+				DFC0A6EDD126A398E4EFD1064C845A3E /* NSEnumerator+RACSequenceAdditions.h in Headers */,
+				DD199BF2916E4F7F43CEED36A90DD7A9 /* NSFileHandle+RACSupport.h in Headers */,
+				80BE5C070AE147B161D48E60FAEC6B8C /* NSIndexSet+RACSequenceAdditions.h in Headers */,
+				C8EF7D6AC3DF55AEBD48C0EBDB4BFF6E /* NSInvocation+RACTypeParsing.h in Headers */,
+				790F4823D5DFD9E7EB0F5F4B21D8282A /* NSNotificationCenter+RACSupport.h in Headers */,
+				8289E750DB5C229947DC601F198223EB /* NSObject+RACAppKitBindings.h in Headers */,
+				BF6FAE6F536CCAA08E718253E29D5145 /* NSObject+RACDeallocating.h in Headers */,
+				74311654F1A4C56D31DB5473AF8124F3 /* NSObject+RACDescription.h in Headers */,
+				D60023D8FA38BBAD91E7A9CDBBE34DC7 /* NSObject+RACKVOWrapper.h in Headers */,
+				6A94DA27B7C075023E501CBC8B65AECD /* NSObject+RACLifting.h in Headers */,
+				797D8D599EBE11FB6D94F377B42E2637 /* NSObject+RACPropertySubscribing.h in Headers */,
+				634B6B800E8E942FDBC677D0E953AC7D /* NSObject+RACSelectorSignal.h in Headers */,
+				4AE7FE301B03A806EE87BC8353E9459F /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
+				CA9D22906D8BBFA221E513334EC22CC6 /* NSSet+RACSequenceAdditions.h in Headers */,
+				BA1D2EA78EE147EA7FC897FCF9E182D8 /* NSString+RACKeyPathUtilities.h in Headers */,
+				7F94FB05A94E1A8BE09BE463D53A63C5 /* NSString+RACSequenceAdditions.h in Headers */,
+				A4C0764D725510E97180348B00FDB687 /* NSString+RACSupport.h in Headers */,
+				24A380008046FAACA7AD0D04A85D68C9 /* NSText+RACSignalSupport.h in Headers */,
+				9FFFA777E18F98A20D4F1F50FDC459C7 /* NSURLConnection+RACSupport.h in Headers */,
+				325A7526BEAFB95631D3AFB218E5C8E7 /* NSUserDefaults+RACSupport.h in Headers */,
+				08486FFC4688445A70751BB8C5DF83F9 /* RACArraySequence.h in Headers */,
+				FC60F29575F232A0BD2F7AB41DDE3ED4 /* RACBehaviorSubject.h in Headers */,
+				160FB69D2279467D55AE76EA11D4AE4E /* RACBlockTrampoline.h in Headers */,
+				90F95A3315D8D7274EF8306391449538 /* RACChannel.h in Headers */,
+				9B857EC4FF06A02FD604B5175B2D550A /* RACCommand.h in Headers */,
+				87B0C7CE5676D773C655224AD10593D9 /* RACCompoundDisposable.h in Headers */,
+				60C2D21CAED6072EE22E2B992409CE3E /* RACDelegateProxy.h in Headers */,
+				D2B6748FD720AB1F6325964268E98466 /* RACDisposable.h in Headers */,
+				EB323D03410C15EB7B219773F631F1F3 /* RACDynamicSequence.h in Headers */,
+				A13ED79FDCDDC503FA67BDACE27779AF /* RACDynamicSignal.h in Headers */,
+				BCBC0F6456C8C133E23AC2DCDEA758B7 /* RACEagerSequence.h in Headers */,
+				32F83FBE599F3AF8DA452D73ECD5F9B9 /* RACEmptySequence.h in Headers */,
+				9FFBFF312E7B1BE98A717A787F5C312A /* RACEmptySignal.h in Headers */,
+				4D5967FAF31FDE819886D79CDDD15694 /* RACErrorSignal.h in Headers */,
+				ED6E1967EBB0531F3118ABFF88C54C30 /* RACEvent.h in Headers */,
+				A71FC8E1F53DCEFE7CE8DAF316E95594 /* RACEXTKeyPathCoding.h in Headers */,
+				FE5F69AEB71394FC9B40FC947771E7A4 /* RACEXTRuntimeExtensions.h in Headers */,
+				EE606471B0E323DC27A3FD9CDCE79C96 /* RACEXTScope.h in Headers */,
+				5A597B0036427C0A1AA8ABB0A0E5916E /* RACGroupedSignal.h in Headers */,
+				6CB85887650A93C46A3A3E79F187CEEB /* RACImmediateScheduler.h in Headers */,
+				C8DF016DC2B85EDD8C9BA9015D7CD78B /* RACIndexSetSequence.h in Headers */,
+				21A4BD1AFD36021317D47301AAF37A5A /* RACKVOChannel.h in Headers */,
+				1267DCAB237F5C0793FAB87C8447C343 /* RACKVOProxy.h in Headers */,
+				E5760C05E6720421FE24362DA9406ADF /* RACKVOTrampoline.h in Headers */,
+				E01B6FC0037A6BF0CDAE1BA4788E35D8 /* RACmetamacros.h in Headers */,
+				491E350E2CDFD0EE30242E641F7A16E2 /* RACMulticastConnection+Private.h in Headers */,
+				4B45D53B31AB8A6F04941E9468A24278 /* RACMulticastConnection.h in Headers */,
+				FAC446E71E3DA85C1CB0D32CD012CFD0 /* RACObjCRuntime.h in Headers */,
+				FF5658A37CAF9E6BEDA9FBB509CA7049 /* RACPassthroughSubscriber.h in Headers */,
+				985DED2802235D2C042A761AF391A362 /* RACQueueScheduler+Subclass.h in Headers */,
+				7342B976B24215E8BB5FE589DE568828 /* RACQueueScheduler.h in Headers */,
+				21AF34D94354912663DD0086A6FEC5A9 /* RACReplaySubject.h in Headers */,
+				5AEBD084A2DC3CAC400466720A866EC3 /* RACReturnSignal.h in Headers */,
+				3924A7D1C49FED56E96BD32DA310991D /* RACScheduler+Private.h in Headers */,
+				4724EDBE9E9B968E86F4D8DE3390CE79 /* RACScheduler+Subclass.h in Headers */,
+				19C384DEA5FB7487299A66B30FF06EAA /* RACScheduler.h in Headers */,
+				69A5F8809D7788AE8D740648FD9EE3C2 /* RACScopedDisposable.h in Headers */,
+				103587B2B6492C05C5F673E5DDB1DF9F /* RACSequence.h in Headers */,
+				D6AC6D6D1D929CEA0D965C2917DAA233 /* RACSerialDisposable.h in Headers */,
+				2FDFF6217DCC4ECD94B75AAE7832C984 /* RACSignal+Operations.h in Headers */,
+				42EF0E0EB115112537E414F4D60F6ACD /* RACSignal.h in Headers */,
+				42A83B107791771456B3C821BA457E57 /* RACSignalSequence.h in Headers */,
+				2644AE63C581B71C12C339D49AEE594E /* RACStream+Private.h in Headers */,
+				70B8BEBBCC6412F9189AD5F6213BD31D /* RACStream.h in Headers */,
+				6353F8694337CD11DAAC99DE19B0109C /* RACStringSequence.h in Headers */,
+				B2F9F3759F20C44425A2A3D79A5ADBB6 /* RACSubject.h in Headers */,
+				E77B1D36D14273657C02E17E20FCD927 /* RACSubscriber+Private.h in Headers */,
+				E137F6DC42841C34844E4DA9B6853EA5 /* RACSubscriber.h in Headers */,
+				6AEBA39571AAC1DB29984590663B6F32 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
+				69C8DEF8CDD1B42321FEC2A162CEA409 /* RACSubscriptionScheduler.h in Headers */,
+				ADB4472A646F236085FCE282E4321F92 /* RACTargetQueueScheduler.h in Headers */,
+				32564E028AC0A0FB8EB01CEC3A719985 /* RACTestScheduler.h in Headers */,
+				B96004809CE9A3CD070099DBD1DF3324 /* RACTuple.h in Headers */,
+				9F008889BD073E4C938D402CC3FD22D4 /* RACTupleSequence.h in Headers */,
+				C95707ED83A75AE6E877D10774CC6504 /* RACUnarySequence.h in Headers */,
+				C84F9B7881F87F8421147BF15934F9C7 /* RACUnit.h in Headers */,
+				55FE21BE82DA423872337A780B9AF9C8 /* RACValueTransformer.h in Headers */,
+				5D5DB5DAE4F502291077D57A66D4C852 /* ReactiveCocoa.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E17381197F2F2A2BE6FE6CB2545EDC7E /* Headers */ = {
+		B66081CA7DB2D6A25F1852962A777B46 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A520EC6CD4D05B61422686C5D025E5DD /* TUSafariActivity.h in Headers */,
+				47CCCF4D8540869DCBCE42ABEBF466DA /* ARChromeActivity.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EAF50D2DC0666B66B2B05D1F5C298DFD /* Headers */ = {
+		C66D331F4D85986A8064A6483FA4F954 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8FC0803F7EEBBE253C5D040884AEDE6F /* RVMViewModel.h in Headers */,
-				E867576364DD77C1712CC865F84CAA1A /* ReactiveViewModel.h in Headers */,
+				E44C3CA841038E56D04787F48325D845 /* ReactiveViewModel.h in Headers */,
+				70676542E0F231901F73850E42F9E43E /* RVMViewModel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1CBAE1D2F2A5C12C0997DEC34CD1DA08 /* TUSafariActivity-TUSafariActivity */ = {
+		5D7F92A58C11C2893698E38921495622 /* Pods-OSXDemo-ReactiveViewModel */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = DC4459C6E7D097C196B4E8E8AD6DEC8D /* Build configuration list for PBXNativeTarget "TUSafariActivity-TUSafariActivity" */;
+			buildConfigurationList = 6B8C3065457B0DBCBC9EC8904C4D8CB6 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveViewModel" */;
 			buildPhases = (
-				A6E9F20D97D717A488CD34DB8F9036E0 /* Sources */,
-				36C58AFDD241229AB571D0A66B6D4FB4 /* Frameworks */,
-				CE3EA1FC7B8CD0173B37699E2B8562D4 /* Resources */,
+				245BDA0C8CE430C156B9F3BA4AEB57D6 /* Sources */,
+				F5284AF7F25F62C5FD15032F3832685A /* Frameworks */,
+				3B0AFFC7D72150A1C1412BF442A41187 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				456F2B4B5736007E6A70AB038D7C7479 /* PBXTargetDependency */,
+			);
+			name = "Pods-OSXDemo-ReactiveViewModel";
+			productName = "Pods-OSXDemo-ReactiveViewModel";
+			productReference = 235C4CF7D2AFE8FCDC571771F68A2287 /* libPods-OSXDemo-ReactiveViewModel.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8991DEA8DD1EB144E05885B3DBEFF046 /* TUSafariActivity-TUSafariActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8121FC6604E1415DF7EAA38136F62F82 /* Build configuration list for PBXNativeTarget "TUSafariActivity-TUSafariActivity" */;
+			buildPhases = (
+				4FDE13EAFC7388889519BB561992EF6F /* Sources */,
+				0644A2D8D63081745140D703B4D769C8 /* Frameworks */,
+				81280FE552A0DB7B8E6BC241AA33679B /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1562,88 +1572,36 @@
 			);
 			name = "TUSafariActivity-TUSafariActivity";
 			productName = "TUSafariActivity-TUSafariActivity";
-			productReference = F9B82514055D19AB45D98F525AD88BC1 /* TUSafariActivity.bundle */;
+			productReference = 39E3BE57B38E6B4994C83783F83AAC26 /* TUSafariActivity.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
-		4C01D71208D4320C07AEB2B7EDE0AE11 /* Pods-iOSDemo-ReactiveViewModel */ = {
+		9F67BAD91BCFB8CAF6CCB64939D7FCF5 /* Pods-iOSDemo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 674B028282083A5C14D43F6039243211 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveViewModel" */;
+			buildConfigurationList = 50A8E47049F6D1795D91C99793433FF1 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo" */;
 			buildPhases = (
-				9A41BBBBD6C7093C9EA3D8C61902F4B0 /* Sources */,
-				BA338BD54352389850C5B489E8DF2AE9 /* Frameworks */,
-				EAF50D2DC0666B66B2B05D1F5C298DFD /* Headers */,
+				03BF5A7FE7DC9EF199167F62AB6B5605 /* Sources */,
+				F0123B81C7670E10B4824845BF54A0AC /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				A02CBDF3E422AD4180D3CC5DEEDF4AE2 /* PBXTargetDependency */,
+				62B0FC8F1502860E79CFA4F7DFC5234F /* PBXTargetDependency */,
+				01B382303B410BFA0894ECCB97FD4843 /* PBXTargetDependency */,
+				2A54DCEEAA05D37A328E2B0091022B7F /* PBXTargetDependency */,
+				EA2452DAC41618857983FB7F9CF6F315 /* PBXTargetDependency */,
 			);
-			name = "Pods-iOSDemo-ReactiveViewModel";
-			productName = "Pods-iOSDemo-ReactiveViewModel";
-			productReference = A35FCD5B3D1F60E5A649F79BEC781AE1 /* libPods-iOSDemo-ReactiveViewModel.a */;
+			name = "Pods-iOSDemo";
+			productName = "Pods-iOSDemo";
+			productReference = B507DBC4C240E2456A33DF9E4090574C /* libPods-iOSDemo.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		9E3A92FD611AB2837032C6A078B63997 /* Pods-OSXDemo-ReactiveViewModel */ = {
+		B673783A58522C909E63B68F082A7522 /* Pods-iOSDemo-ReactiveCocoa */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5AA93334CEAC2CC1C362CE01DCF3F7D4 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveViewModel" */;
+			buildConfigurationList = DEFC0F41C21BF7D28B8FD9CE9372E4EA /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveCocoa" */;
 			buildPhases = (
-				AE416D3C16DCEF427BEF859ADB1FA459 /* Sources */,
-				5140E0F55C993232D189C0AE16FFCA7F /* Frameworks */,
-				381B89A514D92EE02B27EFEEF95F054F /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				6DEFA770A5072019E821DFF105444E38 /* PBXTargetDependency */,
-			);
-			name = "Pods-OSXDemo-ReactiveViewModel";
-			productName = "Pods-OSXDemo-ReactiveViewModel";
-			productReference = BF578BF5903DF1641C7DE12DBBB71B4A /* libPods-OSXDemo-ReactiveViewModel.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		AB01AC1E73965EF7EE34F8FE343665F7 /* TUSafariActivity */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 63606FD5D8D96F1CA0C3213D349D5B17 /* Build configuration list for PBXNativeTarget "TUSafariActivity" */;
-			buildPhases = (
-				FFCB11E08EBA4CF3D7FBA4F4B491357A /* Sources */,
-				B8E4290A8EBB6D8C32DDF4FE7491BBBF /* Frameworks */,
-				E17381197F2F2A2BE6FE6CB2545EDC7E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				A62F99A89A5EE8001DFEBED5611232C2 /* PBXTargetDependency */,
-			);
-			name = TUSafariActivity;
-			productName = TUSafariActivity;
-			productReference = B99FD257E3984B895A80262D85173949 /* libTUSafariActivity.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		BEDFFECCB047420F2A653944C8136520 /* Pods-OSXDemo */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7C72E7E03D32B9518683E75329470212 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo" */;
-			buildPhases = (
-				3A21AE77C626CA40005D17736A8BB41B /* Sources */,
-				31B5D696CE8B7930BEAF8396956A49FA /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				C4835EB4A66AC25D868043AF20D8E576 /* PBXTargetDependency */,
-				1135BB5E89A0BA788232B66511D8B09C /* PBXTargetDependency */,
-			);
-			name = "Pods-OSXDemo";
-			productName = "Pods-OSXDemo";
-			productReference = F077C8F8D77D4BE463481167448A3342 /* libPods-OSXDemo.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		C2D9DA1C1FD5024961E405263D6146C5 /* Pods-iOSDemo-ReactiveCocoa */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1ED95250274DA9BA765A8B63A10EB223 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveCocoa" */;
-			buildPhases = (
-				EA40D86A1C22CD8E388B04CD91EDA979 /* Sources */,
-				B50E38BA603C779A8BA0F6846DDAC9B2 /* Frameworks */,
-				B6E8B871FF480C9AD26CB996753B5ACA /* Headers */,
+				00A04A6F84E3E805EE2AE5BA24BB1D15 /* Sources */,
+				146074E818035510BD7EF6361FF095B8 /* Frameworks */,
+				2F222249943276A96CE1AE42193F102D /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1651,53 +1609,34 @@
 			);
 			name = "Pods-iOSDemo-ReactiveCocoa";
 			productName = "Pods-iOSDemo-ReactiveCocoa";
-			productReference = DA24B7F885E15C578578B6BD2C5E7511 /* libPods-iOSDemo-ReactiveCocoa.a */;
+			productReference = B0037FA89196A9C782176E61F86BF72A /* libPods-iOSDemo-ReactiveCocoa.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		DD5EAA0198EAE9CE9D3C77CFC5ADBAB4 /* Pods-iOSDemo */ = {
+		BBFAB2A0D0FCDE4FC9680B0788D1F4D5 /* Pods-OSXDemo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = EAF05411A51D727F4B0BF78330076B45 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo" */;
+			buildConfigurationList = 183A912B16DFBE337AC287C1350607C0 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo" */;
 			buildPhases = (
-				5E361BFEC5FDB42AB83D5D3597E944FE /* Sources */,
-				20E2087575CB2DB3A5367AD997C3849B /* Frameworks */,
+				EB725A99AB4CCF9C1FFBF109D49FC66C /* Sources */,
+				A39BC297797D852B4AB00E7A40252D9F /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				CF999BB1D0E554D82B69C39D0823C0C0 /* PBXTargetDependency */,
-				67B61A9C308CEB348CC9B8B8313BCF4A /* PBXTargetDependency */,
-				1525B3604ADFB8F5D318220C9FD45775 /* PBXTargetDependency */,
-				222B4E155EFA132FE66AE358DD8204DA /* PBXTargetDependency */,
+				01F3C3688BF931F414BB56745112CB68 /* PBXTargetDependency */,
+				7F56E59B95C9EC656EEE8815FC247E71 /* PBXTargetDependency */,
 			);
-			name = "Pods-iOSDemo";
-			productName = "Pods-iOSDemo";
-			productReference = 233E2535C90C8FB3CA860678CFB12392 /* libPods-iOSDemo.a */;
+			name = "Pods-OSXDemo";
+			productName = "Pods-OSXDemo";
+			productReference = 033D56448351C3C2E66F95B8CDD8AD6C /* libPods-OSXDemo.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		F9609BB655C4B4B12EA7438D41309D59 /* ARChromeActivity */ = {
+		E718017CE7E7390CCB4CD9E0316ACBA4 /* Pods-OSXDemo-ReactiveCocoa */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 780AACAF55955E4BBBCA1B3B38621195 /* Build configuration list for PBXNativeTarget "ARChromeActivity" */;
+			buildConfigurationList = 6191D12FF34563FBC0A1278CE80D2C15 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveCocoa" */;
 			buildPhases = (
-				DCBC10BFE06053B37985C7ABD79E0F47 /* Sources */,
-				903E76D5C323554E18392DC27F072E30 /* Frameworks */,
-				9D1BD6FAECC44155792A830FE1B8AD8F /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ARChromeActivity;
-			productName = ARChromeActivity;
-			productReference = EEE9FB22B588D60581B7BE13A5E1F720 /* libARChromeActivity.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		FBE0B85B81D9A77E4EC5D824DFA329F2 /* Pods-OSXDemo-ReactiveCocoa */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D08CD3818880127C91B673353C43239E /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveCocoa" */;
-			buildPhases = (
-				5EFF472DE3B54CF11B10F7C3545DD754 /* Sources */,
-				EF45DA237653577E21470BE03BE16A39 /* Frameworks */,
-				810B4C723C166D86DA8F12BA63F8EF0F /* Headers */,
+				05138AF5F04F9C6853CA79FC6A420D13 /* Sources */,
+				91958FD7FD551866096C4ED2FA19D505 /* Frameworks */,
+				A0BCA820D910F3F76D85C73E5FB7DEBA /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1705,7 +1644,60 @@
 			);
 			name = "Pods-OSXDemo-ReactiveCocoa";
 			productName = "Pods-OSXDemo-ReactiveCocoa";
-			productReference = A6ACADEDEECCBFAA57DE01838F58A4A2 /* libPods-OSXDemo-ReactiveCocoa.a */;
+			productReference = 05B7537A9C61D330D19940B358C327A8 /* libPods-OSXDemo-ReactiveCocoa.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F2CD58A8C0273CF22017094FB7192EAF /* Pods-iOSDemo-ReactiveViewModel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 31C5EDC8C779F85C75EFCFADB4B89AF1 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveViewModel" */;
+			buildPhases = (
+				1AFAE71165CB9F67D015209B8397934A /* Sources */,
+				77EA035214079B3493072072BA713AA2 /* Frameworks */,
+				C66D331F4D85986A8064A6483FA4F954 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				961D1EEC48DA470CC9975BD154DC7B99 /* PBXTargetDependency */,
+			);
+			name = "Pods-iOSDemo-ReactiveViewModel";
+			productName = "Pods-iOSDemo-ReactiveViewModel";
+			productReference = 6E3EF5B019FA0D87FDE0A2978F087E1E /* libPods-iOSDemo-ReactiveViewModel.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F46241A63E3DAF75A95934F35E3D4B07 /* TUSafariActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 544C02D5C08A031625E4E6E1311689E2 /* Build configuration list for PBXNativeTarget "TUSafariActivity" */;
+			buildPhases = (
+				D0BEE3127C9133C5E8F5D8B94D1F853F /* Sources */,
+				91585807DE0C8450DF19BC98C576A341 /* Frameworks */,
+				9E5D254E124F7DC163207B83F490091D /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				34EB2E386DCCB8534D57FCF4E859A0D7 /* PBXTargetDependency */,
+			);
+			name = TUSafariActivity;
+			productName = TUSafariActivity;
+			productReference = 967C40AB234F3FA17185F324D2037CBC /* libTUSafariActivity.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F7AF14DD2431C8DA79F45F4F1D22075E /* ARChromeActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0769708EDA53D8336E6B8B69595B889F /* Build configuration list for PBXNativeTarget "ARChromeActivity" */;
+			buildPhases = (
+				DDBD0FD31AF907D58FD2B517C7F65C59 /* Sources */,
+				48625C5396F569E5126020D98049AE7D /* Frameworks */,
+				B66081CA7DB2D6A25F1852962A777B46 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ARChromeActivity;
+			productName = ARChromeActivity;
+			productReference = 6875BC26EFDB0A1C55A6A9C5ECB3C160 /* libARChromeActivity.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -1725,395 +1717,367 @@
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = CCA510CFBEA2D207524CDA0D73C3B561 /* Products */;
+			productRefGroup = 9D00EA2FC3F4ADBADB491D2463A26012 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				F9609BB655C4B4B12EA7438D41309D59 /* ARChromeActivity */,
-				BEDFFECCB047420F2A653944C8136520 /* Pods-OSXDemo */,
-				FBE0B85B81D9A77E4EC5D824DFA329F2 /* Pods-OSXDemo-ReactiveCocoa */,
-				9E3A92FD611AB2837032C6A078B63997 /* Pods-OSXDemo-ReactiveViewModel */,
-				DD5EAA0198EAE9CE9D3C77CFC5ADBAB4 /* Pods-iOSDemo */,
-				C2D9DA1C1FD5024961E405263D6146C5 /* Pods-iOSDemo-ReactiveCocoa */,
-				4C01D71208D4320C07AEB2B7EDE0AE11 /* Pods-iOSDemo-ReactiveViewModel */,
-				AB01AC1E73965EF7EE34F8FE343665F7 /* TUSafariActivity */,
-				1CBAE1D2F2A5C12C0997DEC34CD1DA08 /* TUSafariActivity-TUSafariActivity */,
+				F7AF14DD2431C8DA79F45F4F1D22075E /* ARChromeActivity */,
+				9F67BAD91BCFB8CAF6CCB64939D7FCF5 /* Pods-iOSDemo */,
+				B673783A58522C909E63B68F082A7522 /* Pods-iOSDemo-ReactiveCocoa */,
+				F2CD58A8C0273CF22017094FB7192EAF /* Pods-iOSDemo-ReactiveViewModel */,
+				BBFAB2A0D0FCDE4FC9680B0788D1F4D5 /* Pods-OSXDemo */,
+				E718017CE7E7390CCB4CD9E0316ACBA4 /* Pods-OSXDemo-ReactiveCocoa */,
+				5D7F92A58C11C2893698E38921495622 /* Pods-OSXDemo-ReactiveViewModel */,
+				F46241A63E3DAF75A95934F35E3D4B07 /* TUSafariActivity */,
+				8991DEA8DD1EB144E05885B3DBEFF046 /* TUSafariActivity-TUSafariActivity */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		CE3EA1FC7B8CD0173B37699E2B8562D4 /* Resources */ = {
+		81280FE552A0DB7B8E6BC241AA33679B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5F55A260E7BE6B6D9D706ED1A7B6C3EB /* cs.lproj in Resources */,
-				5B226AE321F1481E9CE4E7C45521FC39 /* de.lproj in Resources */,
-				6C6F9D2ACF5BA753183CB71133558343 /* en.lproj in Resources */,
-				CC9A3BBA5E5A08F8AC0E336668F43467 /* es.lproj in Resources */,
-				6949F58AC8D3A616B14B2320185BEE23 /* eu.lproj in Resources */,
-				87E21073ED0BB4578EE1388EB54C9187 /* fi.lproj in Resources */,
-				E7DE07D4798D08611ADE1EF1A4047EBB /* fr.lproj in Resources */,
-				1D936598226DDE5B8AD9FF29DEAADCC9 /* it.lproj in Resources */,
-				97960449617CE1E817CD64C5A5BB5347 /* ja.lproj in Resources */,
-				C5B8654296CE5155598AC8EBA0ECC98A /* ko.lproj in Resources */,
-				3EAC3FC2559E7E7974E9E1E5C1CE1FE5 /* nl.lproj in Resources */,
-				C32705A6FF471E130AD9747DA6E666E6 /* no.lproj in Resources */,
-				C19B9324E6BAADA953F7CC5D1B902476 /* pl.lproj in Resources */,
-				4517FDB1EFD1AA7935156F45B31EE0C5 /* pt.lproj in Resources */,
-				A3CB732301F1FF93F429489A41AB29EC /* ru.lproj in Resources */,
-				186B8774D2A3487CE34587182E894A84 /* safari-7.png in Resources */,
-				9019E7B277D7B81603056B6222AFE103 /* safari-7@2x.png in Resources */,
-				C785C1665E7C61D86C2B000F05729FEF /* safari-7@3x.png in Resources */,
-				27F7DF084F86D1FA892C253F869E4DB0 /* safari-7~iPad.png in Resources */,
-				8819594680C6EC439F9F988CC8BC31C6 /* safari-7~iPad@2x.png in Resources */,
-				B4BFCF617407BFFDEED4DF0425FF1265 /* safari.png in Resources */,
-				31776600E1AF84911E105433370B75A3 /* safari@2x.png in Resources */,
-				B305A27EC919C81E6A226F1417DDEB5A /* safari@3x.png in Resources */,
-				E795D5CF2F8EE77627C7BFE4AD545E46 /* safari~iPad.png in Resources */,
-				17C6FD4E5531A209C70A256175E7DEA2 /* safari~iPad@2x.png in Resources */,
-				F09B1D17E2693D8CC36351A5B5AEC66B /* sk.lproj in Resources */,
-				9EBF6A835072B8C0FDB0F9BD05CB8FD5 /* sv.lproj in Resources */,
-				1426916AC588B5FE2BDA5DD9564906DE /* vi.lproj in Resources */,
-				86B8F575CDDE4A082BA338C4391E5F92 /* zh_CN.lproj in Resources */,
+				330DAF44DEE4EBE3FE1165F0EC045968 /* cs.lproj in Resources */,
+				9990B2DC98D7A6112BD4AB4635A493EB /* de.lproj in Resources */,
+				94C9378C149478E31A752D7ED71B36BC /* en.lproj in Resources */,
+				A14156FD061CD7E21AA265500E280396 /* es.lproj in Resources */,
+				D1E9B705788BCA951B51E9552A4C5E24 /* eu.lproj in Resources */,
+				3D8028AB60ABCF62BBBA8074AC20ECD1 /* fi.lproj in Resources */,
+				01B8481BF91BF0313617CF7EE607169F /* fr.lproj in Resources */,
+				E8FD5158C924BC33EC819528234C4926 /* it.lproj in Resources */,
+				ABC4E0EA84D34215F8B352C7915A8661 /* ja.lproj in Resources */,
+				BA78591CAFE4E3076468CE9B95F25C6B /* ko.lproj in Resources */,
+				55184B6F485B0CD811419F99A3CD554F /* nl.lproj in Resources */,
+				72633C7DE1A92E9D73746EE786608DE9 /* no.lproj in Resources */,
+				E8F2CEFD7B8D18A9FCFC07DA12CE6BD7 /* pl.lproj in Resources */,
+				1B472340BB445CBEE517A2E2E472A5B6 /* pt.lproj in Resources */,
+				7242077BD560139759E8F5C9A1762F3B /* ru.lproj in Resources */,
+				AA8740404708D8E4CD437BA5E3C7142E /* safari-7.png in Resources */,
+				33DC995BB8D22582E10630DA4006FD67 /* safari-7@2x.png in Resources */,
+				58B029FECC4588E77CB6D4FA3F2C1482 /* safari-7@3x.png in Resources */,
+				98F05612F9E8334C7288B9B8F5AC7186 /* safari-7~iPad.png in Resources */,
+				C42D854D6610C7DA12667853AC649BD6 /* safari-7~iPad@2x.png in Resources */,
+				50B607DAA049C3ACF3E128925D08F2BF /* safari.png in Resources */,
+				6401914D77F3F0FEE8557DA2EFCD2F7F /* safari@2x.png in Resources */,
+				35F79F6CEE83CDE7A0377CEAE41F05A8 /* safari@3x.png in Resources */,
+				4EC010219039EFAACE3C2FAE260BF38A /* safari~iPad.png in Resources */,
+				BEFA37180F24EE64E6DF7957A12202A0 /* safari~iPad@2x.png in Resources */,
+				E2718E832472A325B1F0B61B1F3379A0 /* sk.lproj in Resources */,
+				7219FDEDCB4EA278510C2D8AEA95FDEC /* sv.lproj in Resources */,
+				EA21823F8D314775E05C60990EC56E69 /* vi.lproj in Resources */,
+				913FFC34D5D240F643B27C7E621032FF /* zh_CN.lproj in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		3A21AE77C626CA40005D17736A8BB41B /* Sources */ = {
+		00A04A6F84E3E805EE2AE5BA24BB1D15 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2AA222C5565955BAB01C36EC85A18C98 /* Pods-OSXDemo-dummy.m in Sources */,
+				22E68008D356F1B7538753EDB2DB82A2 /* MKAnnotationView+RACSignalSupport.m in Sources */,
+				3C8652913DF3E64CFF3EC6F93C159F0A /* NSArray+RACSequenceAdditions.m in Sources */,
+				FCA630DAB92D855A2438A8773A297A9D /* NSData+RACSupport.m in Sources */,
+				7A92FFE72E1D9E7104AAF36F47D55AF9 /* NSDictionary+RACSequenceAdditions.m in Sources */,
+				5B366C4AEA75077D75E6E16EFF597EA3 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
+				C520EBE8A7F9E3DF0D64ED49C7293D71 /* NSFileHandle+RACSupport.m in Sources */,
+				DF5FDCC7614A1278EB9CAF0CDE01E16F /* NSIndexSet+RACSequenceAdditions.m in Sources */,
+				036C7CB2EE1806F298618AFE3ADB1A8A /* NSInvocation+RACTypeParsing.m in Sources */,
+				84FF70A804A6CCB482FEF07647992970 /* NSNotificationCenter+RACSupport.m in Sources */,
+				7DACE2B34C5BAD3FC3F0F260A4B373E9 /* NSObject+RACDeallocating.m in Sources */,
+				B2893984FA5912CCA30AB4234C2D6C45 /* NSObject+RACDescription.m in Sources */,
+				7C2F536116C751D8B1436C379FE6F901 /* NSObject+RACKVOWrapper.m in Sources */,
+				C9C35AAB875C93DF217029D39C6E224D /* NSObject+RACLifting.m in Sources */,
+				0D2967C848E2DEEF5C51F04A22F0FB6C /* NSObject+RACPropertySubscribing.m in Sources */,
+				306921F8DB0F8A4F9DA21617F74AD094 /* NSObject+RACSelectorSignal.m in Sources */,
+				D6947F8F0DCDE810ADDA7C944DE508A9 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
+				14D70549A53F7FBF39AFA4B6B3BA97A3 /* NSSet+RACSequenceAdditions.m in Sources */,
+				8CFAA51E7C93C300C15FBB3508E81672 /* NSString+RACKeyPathUtilities.m in Sources */,
+				9F9ED259115C94CC1CACA10F318885BD /* NSString+RACSequenceAdditions.m in Sources */,
+				D60DA7B68B821CDA2FBA1BFA05C15959 /* NSString+RACSupport.m in Sources */,
+				7F71B7FCDE2E4553DB2E329E6803046C /* NSURLConnection+RACSupport.m in Sources */,
+				2D60A33E08E8B99C6B66F844D2B47D5E /* NSUserDefaults+RACSupport.m in Sources */,
+				CF5508084EA1772F60ADC1086D7A2B04 /* Pods-iOSDemo-ReactiveCocoa-dummy.m in Sources */,
+				2AC330ED36C83AECCC854B30EC2AF2D5 /* RACArraySequence.m in Sources */,
+				8D7B2C5A28568FEB2F4E3510FD59E50A /* RACBehaviorSubject.m in Sources */,
+				2B197E526801BBA4134DF0442B4BCFF3 /* RACBlockTrampoline.m in Sources */,
+				A0332DE252987782135D10A0A746A32B /* RACChannel.m in Sources */,
+				744860CB40ED957211E098C361530F79 /* RACCommand.m in Sources */,
+				2B24E6F865D0C6F6815787F1EB37DA90 /* RACCompoundDisposable.m in Sources */,
+				7AFDFF6E6D18328563E6ADB870CA7F97 /* RACCompoundDisposableProvider.d in Sources */,
+				31EE3AD7E1A14098B69EB9168BEEAC81 /* RACDelegateProxy.m in Sources */,
+				EF3E6833E561B3BE87E2FF525FB71EED /* RACDisposable.m in Sources */,
+				140EB2328856617C96FB1B75331901FC /* RACDynamicSequence.m in Sources */,
+				7AE72FD45684A8BAEEBD8B644A2B3B0B /* RACDynamicSignal.m in Sources */,
+				7BA41B30F730D2F9258C2D08E7572E28 /* RACEagerSequence.m in Sources */,
+				B78AEB64B89FCFA6FE4F5E6AE2F9A4FC /* RACEmptySequence.m in Sources */,
+				C1A5C6BCCE51D8FA2A884BCD7B07B7FC /* RACEmptySignal.m in Sources */,
+				7A87F615316DBAA1C85E6E992EC139D3 /* RACErrorSignal.m in Sources */,
+				E3FBC7F0AB128DEE4456098AA6238E30 /* RACEvent.m in Sources */,
+				7028321755D0B135D27616C1730BAD94 /* RACEXTRuntimeExtensions.m in Sources */,
+				61F0F00F1402C48DDCF9FB0984941B6D /* RACGroupedSignal.m in Sources */,
+				B1FE1165653B2F34AF35E491A18BE2FE /* RACImmediateScheduler.m in Sources */,
+				8F188AD6B3B27F411A5F2FCBB6AC5593 /* RACIndexSetSequence.m in Sources */,
+				76C2FDA8E565D7233515977078F8AA95 /* RACKVOChannel.m in Sources */,
+				3FABEB04EF7E79666FA7C46D1E58F417 /* RACKVOProxy.m in Sources */,
+				621451D209C7889C0407B5ED59C2CCC9 /* RACKVOTrampoline.m in Sources */,
+				A3AECA61E6B413E3FDE9F02F570BE99E /* RACMulticastConnection.m in Sources */,
+				7B0FE3189C06D59BC1AE38E83DFD6AF0 /* RACObjCRuntime.m in Sources */,
+				48EC0CA26B0D060C1DA66E429A98A7BC /* RACPassthroughSubscriber.m in Sources */,
+				B8702EE4FD0DAAED8B1A66F423C4F97F /* RACQueueScheduler.m in Sources */,
+				F0E575B35C637764025F2288FDE558BB /* RACReplaySubject.m in Sources */,
+				74B1715740039E07122DB9623C89EBF1 /* RACReturnSignal.m in Sources */,
+				3C77ED8A9F8F8C66299FC779702552FB /* RACScheduler.m in Sources */,
+				7D9AF1A6F8EFE65515E0C09895D8F32D /* RACScopedDisposable.m in Sources */,
+				A54BA1E8B2BBBC88D10A0D3FCBE68CF6 /* RACSequence.m in Sources */,
+				1D7E48190225C92343750181BCE26079 /* RACSerialDisposable.m in Sources */,
+				D553980DF172ACADB0A507B15CA17550 /* RACSignal+Operations.m in Sources */,
+				FF92AC25F3FD89B50CF92CAC42E25670 /* RACSignal.m in Sources */,
+				F868447049EC07E3AD9CEEB1BC1763BE /* RACSignalProvider.d in Sources */,
+				F946C18662E67F5FE37970964B8AA68D /* RACSignalSequence.m in Sources */,
+				1A6816A49F5D7503A3665E159503330F /* RACStream.m in Sources */,
+				DB16A37E586A62A7E5B8218DE641293D /* RACStringSequence.m in Sources */,
+				12C113A535AA7DDB89CD9186340418AA /* RACSubject.m in Sources */,
+				F539E74136C991BD1394A083A9F5D979 /* RACSubscriber.m in Sources */,
+				9F4DF02EAEDA61C3F6B5B56EE2FD4040 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
+				EFD198F16B31FF97259F92E70549F1F8 /* RACSubscriptionScheduler.m in Sources */,
+				4DD088F8B27FA050794544B5EB44EF24 /* RACTargetQueueScheduler.m in Sources */,
+				1687336A349D0889758BBECE1770F88A /* RACTestScheduler.m in Sources */,
+				1A3935E07B4DDAAFB6A737EA96D1291A /* RACTuple.m in Sources */,
+				263C0F41EDBC2D971CA86BB63B0B875D /* RACTupleSequence.m in Sources */,
+				215CA1078AD1ED82B0435AE8C2333FB3 /* RACUnarySequence.m in Sources */,
+				B8CF27DB6DABE0B713A4E19FC549DB97 /* RACUnit.m in Sources */,
+				62FACD6C175CA25B0EE256DB3D2213E1 /* RACValueTransformer.m in Sources */,
+				0936D261C1B7D307897FBB7C76A4421A /* UIActionSheet+RACSignalSupport.m in Sources */,
+				BDDA7D0507B2612911E7C7A1F33F6D2A /* UIAlertView+RACSignalSupport.m in Sources */,
+				3AFA4077781740C73D15A305E3A5DC96 /* UIBarButtonItem+RACCommandSupport.m in Sources */,
+				4D48694FC1B10BD121AD61277A31D566 /* UIButton+RACCommandSupport.m in Sources */,
+				CA2265A3190A6B0672E4DB47B2562EE4 /* UICollectionReusableView+RACSignalSupport.m in Sources */,
+				1255E1BC4545714AD6C18BDB01731813 /* UIControl+RACSignalSupport.m in Sources */,
+				0C08A3DB08203BA94EAEE779DF272D4E /* UIControl+RACSignalSupportPrivate.m in Sources */,
+				7818CEEC583B88D0A9DAC4927361066D /* UIDatePicker+RACSignalSupport.m in Sources */,
+				90BAB98C93795783CD735269025BB586 /* UIGestureRecognizer+RACSignalSupport.m in Sources */,
+				D4B352FDEC810D648AFE18FC8CEFE622 /* UIImagePickerController+RACSignalSupport.m in Sources */,
+				41D3739E1F43057EEB16BF5709C33DCE /* UIRefreshControl+RACCommandSupport.m in Sources */,
+				3B1B8D6FBC2AFDD8D9B157EA86838C9A /* UISegmentedControl+RACSignalSupport.m in Sources */,
+				419981D5FE56FA2332DBF41AA6FD749E /* UISlider+RACSignalSupport.m in Sources */,
+				A4DE2BA462AB433D91A8DC4272BE3231 /* UIStepper+RACSignalSupport.m in Sources */,
+				4010CA5E04882AFCD104BEC8BAEB91EA /* UISwitch+RACSignalSupport.m in Sources */,
+				7575A151BAA30BEE3357FDA3B29BF2F9 /* UITableViewCell+RACSignalSupport.m in Sources */,
+				B4DE5134C3FFA447A6088874D1B5324E /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */,
+				7AE335E44DE3D4054F251471987AB74D /* UITextField+RACSignalSupport.m in Sources */,
+				10DF8E468309FC91E98B82CFA6ECAD3B /* UITextView+RACSignalSupport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5E361BFEC5FDB42AB83D5D3597E944FE /* Sources */ = {
+		03BF5A7FE7DC9EF199167F62AB6B5605 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				24A88225238EE6CD2EAD5B675F8BAB62 /* Pods-iOSDemo-dummy.m in Sources */,
+				308046CACBC6851CFFFEA841AB58BFA9 /* Pods-iOSDemo-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5EFF472DE3B54CF11B10F7C3545DD754 /* Sources */ = {
+		05138AF5F04F9C6853CA79FC6A420D13 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6C7D27EA92FF3225C850AB08765EFAA3 /* NSArray+RACSequenceAdditions.m in Sources */,
-				746D2AE75D2513359D8328DE78CC8F46 /* NSControl+RACCommandSupport.m in Sources */,
-				99EF50AB9148D56963E5BD4F2DEFF198 /* NSControl+RACTextSignalSupport.m in Sources */,
-				DF5997806E1FAF0BAFD193F4A55D6F86 /* NSData+RACSupport.m in Sources */,
-				1C532AB8861F45DF2ECD53CEB73525DE /* NSDictionary+RACSequenceAdditions.m in Sources */,
-				F0019F0AE8D6D8F3AE7D391FFACC9068 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
-				C80F28354C4ED7249222C2A16E1E0E6A /* NSFileHandle+RACSupport.m in Sources */,
-				358C0B9F49097C9C519881411E648693 /* NSIndexSet+RACSequenceAdditions.m in Sources */,
-				E3559B5A2F8700C70193A319EF0F8C93 /* NSInvocation+RACTypeParsing.m in Sources */,
-				EEEA30926D1743F6DBC91CF26044CEDC /* NSNotificationCenter+RACSupport.m in Sources */,
-				0DF577969B4A8022711620DECFF905ED /* NSObject+RACAppKitBindings.m in Sources */,
-				D29397B60DE7492B190522ED637CCA4E /* NSObject+RACDeallocating.m in Sources */,
-				E5B3ABE3E19F94D666BC495F04217F1A /* NSObject+RACDescription.m in Sources */,
-				811D3706743EE1DB1C6BCFBF2EFA6DAE /* NSObject+RACKVOWrapper.m in Sources */,
-				5F910A10642EE0D81046263F6CE3B4D3 /* NSObject+RACLifting.m in Sources */,
-				7A61D0EB0DB34E5CD63B50827B78BE5D /* NSObject+RACPropertySubscribing.m in Sources */,
-				CB468A02004838FB2E7554B8CB0F7B46 /* NSObject+RACSelectorSignal.m in Sources */,
-				002D3489E051E9874EAC4EEB81B1B6FF /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
-				C66C858E6E5C113C9EF63441A4D10964 /* NSSet+RACSequenceAdditions.m in Sources */,
-				242206D245C06F71F082CB7F80AAA085 /* NSString+RACKeyPathUtilities.m in Sources */,
-				7F44A7E67C750567A53EF36439B09DED /* NSString+RACSequenceAdditions.m in Sources */,
-				B0DB5DC033163E4A2F85840B43A3831F /* NSString+RACSupport.m in Sources */,
-				91635254E7BFA5D6A3FCF52C9F92D8A9 /* NSText+RACSignalSupport.m in Sources */,
-				A696D009737EAF3A58AC327900B43AB5 /* NSURLConnection+RACSupport.m in Sources */,
-				8401A2B0C18B7EF200918EB2919E67F6 /* NSUserDefaults+RACSupport.m in Sources */,
-				6F08D63908A4D1483109564BEC8226C3 /* Pods-OSXDemo-ReactiveCocoa-dummy.m in Sources */,
-				14D2C40D26713C03419B7A6CAC2369EC /* RACArraySequence.m in Sources */,
-				757600B75F80A11E85E80A9082068D44 /* RACBehaviorSubject.m in Sources */,
-				E45C47D87A7B53A0D0D85744421C6A8E /* RACBlockTrampoline.m in Sources */,
-				F4B87E3C5BCBD97019343224FC0D7F97 /* RACChannel.m in Sources */,
-				8465CD9D4D357BC77A83BB2BAA6E8EFA /* RACCommand.m in Sources */,
-				8794403DE81BAA6D46C0B1139D64281B /* RACCompoundDisposable.m in Sources */,
-				CF6C8D0AD9A098BC05A82A2E80A9DCD4 /* RACCompoundDisposableProvider.d in Sources */,
-				56249E483277365EEA12EEF83E4A1290 /* RACDelegateProxy.m in Sources */,
-				1FD2E4791BB8DCE4FF6D745013905FA1 /* RACDisposable.m in Sources */,
-				B03A6ADC353F6FECF76C17FD00694FFB /* RACDynamicSequence.m in Sources */,
-				A0EC6CF4B3706D18E86AAF8BB3C97215 /* RACDynamicSignal.m in Sources */,
-				016F49B97B96E9C284C4497EB851DCB7 /* RACEXTRuntimeExtensions.m in Sources */,
-				7CD3466C4C8D03BA23B5FE1B212268EE /* RACEagerSequence.m in Sources */,
-				147D4F234044E3AA3BA319FA504A3F9C /* RACEmptySequence.m in Sources */,
-				1349633B8FFAECD87EDBA83AA7534360 /* RACEmptySignal.m in Sources */,
-				C50E26ED8DE1891C98BE9CDDA2A229BA /* RACErrorSignal.m in Sources */,
-				E6170D09B4A04587B9467ACAA593FA84 /* RACEvent.m in Sources */,
-				AFF06078503F5F85FF115ED3961F4F98 /* RACGroupedSignal.m in Sources */,
-				7F3FECA299EC0E6F29E43B25A4793B3D /* RACImmediateScheduler.m in Sources */,
-				89134E6CD08DDA0F41335E400BCB318E /* RACIndexSetSequence.m in Sources */,
-				87A56A8FB110B1B28CCE8A083334F5CA /* RACKVOChannel.m in Sources */,
-				E5C2EB542C61158CFF3E0A684CD3614E /* RACKVOProxy.m in Sources */,
-				04A801A5E7B95C14A7ECB6D1C7606417 /* RACKVOTrampoline.m in Sources */,
-				CB03CC766ACEF4029B0E4A202E249774 /* RACMulticastConnection.m in Sources */,
-				2400225244487B000FA192785D9671D6 /* RACObjCRuntime.m in Sources */,
-				4C61BD8AB9C6ECCF8245E2B17C95E8BE /* RACPassthroughSubscriber.m in Sources */,
-				61DD6A0CDEACB60D3A56DF1901FF54AA /* RACQueueScheduler.m in Sources */,
-				0931776966C3B3B534958BEA7F2791D4 /* RACReplaySubject.m in Sources */,
-				9A0D890AE82146430B84C92E033959C2 /* RACReturnSignal.m in Sources */,
-				CB4120FB5F2327FC47C6DCD3D598F06D /* RACScheduler.m in Sources */,
-				5124D10978D2BEE748E643598031E884 /* RACScopedDisposable.m in Sources */,
-				927681125672B1F0D9966162632CC512 /* RACSequence.m in Sources */,
-				34420854E398DE1B4211EA0AFDB821D1 /* RACSerialDisposable.m in Sources */,
-				6808C9C4E595422AB2BA2D2C0A516351 /* RACSignal+Operations.m in Sources */,
-				8772AD04525BC05EE86202F61EC37CA9 /* RACSignal.m in Sources */,
-				DFBA9E3E2394C57C223A9567ABA154D1 /* RACSignalProvider.d in Sources */,
-				E5AD7ADFA627E1F283A66D7D2D3F1FA6 /* RACSignalSequence.m in Sources */,
-				24C21BCAA9D6D5A7D032007A11461D07 /* RACStream.m in Sources */,
-				3F09A134D74FA9FB4AC9E04C13F7401A /* RACStringSequence.m in Sources */,
-				AD06B728EA8B22ACCE2528EFE3902F0C /* RACSubject.m in Sources */,
-				9115324E017318936E8ABCEF8B9269E8 /* RACSubscriber.m in Sources */,
-				AD576D97EA33BEEBF18DB84EBE63BAEE /* RACSubscriptingAssignmentTrampoline.m in Sources */,
-				DA099B72FFA334F3C58A032A07FFDABD /* RACSubscriptionScheduler.m in Sources */,
-				81CFC2E6CD6CF66068FEECECCE69B7A5 /* RACTargetQueueScheduler.m in Sources */,
-				C016893182083F85648A960EC3D11546 /* RACTestScheduler.m in Sources */,
-				D86E5A0E6561B3ED90F2D55857C6F9EF /* RACTuple.m in Sources */,
-				7FBF984A2E3D9511FB781D05AFC8E535 /* RACTupleSequence.m in Sources */,
-				D77E407FFC5AF9212A67A35021F23286 /* RACUnarySequence.m in Sources */,
-				7CB1A664AA35AB2155EA43EBAAB35DA4 /* RACUnit.m in Sources */,
-				46204EF42F007AA3376624E522CEC9A0 /* RACValueTransformer.m in Sources */,
+				2384DDDEC3E77EF78389A3E9AE7149DC /* NSArray+RACSequenceAdditions.m in Sources */,
+				4319B6918D45E698DD2AABDBDCE7D71C /* NSControl+RACCommandSupport.m in Sources */,
+				329256B667C459ECAFF57031DB844399 /* NSControl+RACTextSignalSupport.m in Sources */,
+				4D7E9A8F39F6D5DDBB8975AA68B2A8B5 /* NSData+RACSupport.m in Sources */,
+				CBD8B7651425DD27959B598ADA7AB6A2 /* NSDictionary+RACSequenceAdditions.m in Sources */,
+				D34FDA8C926B07BC12D1BBC447F0155E /* NSEnumerator+RACSequenceAdditions.m in Sources */,
+				7C8E8D460C5109ECECE4A99391EFB4E6 /* NSFileHandle+RACSupport.m in Sources */,
+				F6E0A295659E0D25923D783A0EC98E45 /* NSIndexSet+RACSequenceAdditions.m in Sources */,
+				F4915F8FCA94ED63E7F9A43934B7618E /* NSInvocation+RACTypeParsing.m in Sources */,
+				E308177804DF49973F3E7C17B63F231C /* NSNotificationCenter+RACSupport.m in Sources */,
+				7F2D10AA5F43FF53774625D58F26F21E /* NSObject+RACAppKitBindings.m in Sources */,
+				44CE95A22383CE28D00DC5D74069A646 /* NSObject+RACDeallocating.m in Sources */,
+				92E9B030528119A3EBC541ABA13CFD1F /* NSObject+RACDescription.m in Sources */,
+				BAA7E0977ACAF4ED9B2BD360C5BF7CF1 /* NSObject+RACKVOWrapper.m in Sources */,
+				DD1C28B7F6569BC4156760872BF73EAE /* NSObject+RACLifting.m in Sources */,
+				15710646D26A63C065D68497A52EC049 /* NSObject+RACPropertySubscribing.m in Sources */,
+				3989443ADE0FAB49226C8EA11A3F5EC3 /* NSObject+RACSelectorSignal.m in Sources */,
+				EFDED4BFC94D6440213AE1DC01AF3F76 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
+				904F64B48655AD567011A3454ED2E60E /* NSSet+RACSequenceAdditions.m in Sources */,
+				14A60FC439668778788BDCE110678F59 /* NSString+RACKeyPathUtilities.m in Sources */,
+				8FE4E989C08FC9C66A8FE21CC9876E22 /* NSString+RACSequenceAdditions.m in Sources */,
+				A63D974B8A6C6B056B8C6B254E0C2B21 /* NSString+RACSupport.m in Sources */,
+				E6FF15C9EAE778CDF33B23614669ECFC /* NSText+RACSignalSupport.m in Sources */,
+				B6D84DF260EF5E853B39CAEBAB789B0A /* NSURLConnection+RACSupport.m in Sources */,
+				760236F48A5121CD4BA0E0078F279AF2 /* NSUserDefaults+RACSupport.m in Sources */,
+				2937873E2105062E9047C28EC8BA1B19 /* Pods-OSXDemo-ReactiveCocoa-dummy.m in Sources */,
+				AEA7593FEEDAE40ADA64A5D9D0C83043 /* RACArraySequence.m in Sources */,
+				A357960C0B418516D04FEE78AC8B5E50 /* RACBehaviorSubject.m in Sources */,
+				FB0C00FAF8365A912CB3457382463542 /* RACBlockTrampoline.m in Sources */,
+				89120C9623EACC98C2A25C0C074DAFB5 /* RACChannel.m in Sources */,
+				EF495E545B797924F90F4A4BB57B2B42 /* RACCommand.m in Sources */,
+				64D264D84A7DE9B2CB404CCCE1C15F04 /* RACCompoundDisposable.m in Sources */,
+				E085123F7F5F292516CE819C145E8F5A /* RACCompoundDisposableProvider.d in Sources */,
+				188448872FF61B3640F3906ABC170F79 /* RACDelegateProxy.m in Sources */,
+				F816DAF284C79BB70F9898DC503DE2E9 /* RACDisposable.m in Sources */,
+				FE13BA25C2CB67FFB69C6CE5C0A5C555 /* RACDynamicSequence.m in Sources */,
+				4F94EF88BAD65610B6CEC0F979D2C577 /* RACDynamicSignal.m in Sources */,
+				2C7EC603386DEF13A0320ADEE52A0392 /* RACEagerSequence.m in Sources */,
+				06733EE679BFF3F529E284A190EECEBB /* RACEmptySequence.m in Sources */,
+				7FEC5691706596115851881DFD0B4962 /* RACEmptySignal.m in Sources */,
+				EE8466A7F32F044FEBC3FB8C33A0F8C8 /* RACErrorSignal.m in Sources */,
+				0E7BBA23020A8A755DA9DB36EAA7F662 /* RACEvent.m in Sources */,
+				4EBD58DAE8CC90CC6FD652A176667A1C /* RACEXTRuntimeExtensions.m in Sources */,
+				9F192B7764A2C41C25ED137A07D2C387 /* RACGroupedSignal.m in Sources */,
+				6DD0DC71C4E71CF58B9D7A292A7438C2 /* RACImmediateScheduler.m in Sources */,
+				78752545740C402EE509217109A83FA4 /* RACIndexSetSequence.m in Sources */,
+				2FC70E79ED9AE2E66F4AE82706ED73A7 /* RACKVOChannel.m in Sources */,
+				DB8D956A4A11007BB62DD4FC219D9CA1 /* RACKVOProxy.m in Sources */,
+				471FE947A5D86F4862CA51037CE906BA /* RACKVOTrampoline.m in Sources */,
+				E2BA6AE90264F0519BF92DCB03240884 /* RACMulticastConnection.m in Sources */,
+				C4E10461BF72EB34D6C51806F58A8FC1 /* RACObjCRuntime.m in Sources */,
+				D976B67819D93E99E514EBBCB46727B8 /* RACPassthroughSubscriber.m in Sources */,
+				D0453495577B152354EAC0F28DC7C0EC /* RACQueueScheduler.m in Sources */,
+				E1852C39D215715878B14DB3DD3BE95F /* RACReplaySubject.m in Sources */,
+				556B14ED74441A7D6A06DD0CBF9C462B /* RACReturnSignal.m in Sources */,
+				9B1338AB92269C22C8F4F68BC280A752 /* RACScheduler.m in Sources */,
+				97AACD6B173F224F4BE6E2E2B8CAFCA2 /* RACScopedDisposable.m in Sources */,
+				E2439E649B8F830075BE1909D2281903 /* RACSequence.m in Sources */,
+				CEC2DB6B8A072F82C4158C6F50F2EC20 /* RACSerialDisposable.m in Sources */,
+				33379802E099034B34315EA46E02C4A7 /* RACSignal+Operations.m in Sources */,
+				6E7DE96BC6C3523718AE4DF8EA74E82E /* RACSignal.m in Sources */,
+				0FA7C0CB2B5D20E8B68B0D374D236E69 /* RACSignalProvider.d in Sources */,
+				A378EBBA23C14A80ACA1A3CAD2EE5036 /* RACSignalSequence.m in Sources */,
+				34882A162C56E50CA1AB2E67AEEF056B /* RACStream.m in Sources */,
+				9CF265C257EAD177580008AE60A1DCD6 /* RACStringSequence.m in Sources */,
+				75C057FDCAF764B9CAC29E974C67D1E3 /* RACSubject.m in Sources */,
+				2F8CE56AA18ED5228F93D912EFC32448 /* RACSubscriber.m in Sources */,
+				CD80277772AE774D89C88B62C8FE4C56 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
+				C4A787E7BF2C38010226DDB234B2B61A /* RACSubscriptionScheduler.m in Sources */,
+				EBF9E040CD13B87D1BB90D6B0E9C4B92 /* RACTargetQueueScheduler.m in Sources */,
+				0302A7EBA990666865590C424951A987 /* RACTestScheduler.m in Sources */,
+				27279CB0452CC5AC00EC5787E3F8A6C0 /* RACTuple.m in Sources */,
+				44281446CE2F8A031338C1F58600F2B3 /* RACTupleSequence.m in Sources */,
+				BD386F39215A3EACF170CAD50DA79BC3 /* RACUnarySequence.m in Sources */,
+				9D3BBD26CD2D9F1A8B364BAA7AA94D6F /* RACUnit.m in Sources */,
+				D2685D6E4EE5EF3ABDFE5E7DD7FD3EE1 /* RACValueTransformer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9A41BBBBD6C7093C9EA3D8C61902F4B0 /* Sources */ = {
+		1AFAE71165CB9F67D015209B8397934A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0C06B1EC8846131956D97C2D0670A7B2 /* Pods-iOSDemo-ReactiveViewModel-dummy.m in Sources */,
-				1F1425EE1E1BFFD179DFF5C2D01545CC /* RVMViewModel.m in Sources */,
+				2EB11740E7C4F03544D5FB66AE969088 /* Pods-iOSDemo-ReactiveViewModel-dummy.m in Sources */,
+				1888F14D1C9E665A81759BBCD7687997 /* RVMViewModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A6E9F20D97D717A488CD34DB8F9036E0 /* Sources */ = {
+		245BDA0C8CE430C156B9F3BA4AEB57D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA0CD244C665035CBA37EE13BC2F5FFE /* Pods-OSXDemo-ReactiveViewModel-dummy.m in Sources */,
+				2F4C6D2061C4F739119CD253C93558BA /* RVMViewModel.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FDE13EAFC7388889519BB561992EF6F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AE416D3C16DCEF427BEF859ADB1FA459 /* Sources */ = {
+		D0BEE3127C9133C5E8F5D8B94D1F853F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AADA6698017F790577C7A63129A5991E /* Pods-OSXDemo-ReactiveViewModel-dummy.m in Sources */,
-				3A4322957DB1AC11E113DDC151F76D2D /* RVMViewModel.m in Sources */,
+				DCC1F02315FC4B40B0AD825052922889 /* TUSafariActivity-dummy.m in Sources */,
+				E930EA7AD8BEA3F35E5B0A9340F74FBB /* TUSafariActivity.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DCBC10BFE06053B37985C7ABD79E0F47 /* Sources */ = {
+		DDBD0FD31AF907D58FD2B517C7F65C59 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CF2EC65E53B0DB0092BBAF9344D1E310 /* ARChromeActivity-dummy.m in Sources */,
-				207CD65107D72AD18EE8E4702919071E /* ARChromeActivity.m in Sources */,
+				4BDE01072F06E2D612951E7AF96033AB /* ARChromeActivity-dummy.m in Sources */,
+				8F26318EA6559F80FC328A67C3E5EC12 /* ARChromeActivity.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EA40D86A1C22CD8E388B04CD91EDA979 /* Sources */ = {
+		EB725A99AB4CCF9C1FFBF109D49FC66C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				797C09FC1CCEC867881296F3CFD1D42A /* MKAnnotationView+RACSignalSupport.m in Sources */,
-				E472D8D121FEC08A524BF042B12FCB77 /* NSArray+RACSequenceAdditions.m in Sources */,
-				61CC7DF5E59A708B021ECBF7300D5096 /* NSData+RACSupport.m in Sources */,
-				2BF96EACD387B86EA66414E83CBFACFB /* NSDictionary+RACSequenceAdditions.m in Sources */,
-				F278549D9459D74676807AB45B8EC2BF /* NSEnumerator+RACSequenceAdditions.m in Sources */,
-				3727665E40202CD58BC375C84FE880C4 /* NSFileHandle+RACSupport.m in Sources */,
-				C7C8BBBE26B9BB6D6E6954BEA0467C9A /* NSIndexSet+RACSequenceAdditions.m in Sources */,
-				885D0FA049C69D63421D643106005C45 /* NSInvocation+RACTypeParsing.m in Sources */,
-				855D7F11881230499C48D1361350A782 /* NSNotificationCenter+RACSupport.m in Sources */,
-				EA1099414E9768ECEA5FF2D74407B3C0 /* NSObject+RACDeallocating.m in Sources */,
-				090615E6D5D68658B173CE5AC80933D8 /* NSObject+RACDescription.m in Sources */,
-				BA6C6493B4B1440EB1F5B354525F8D52 /* NSObject+RACKVOWrapper.m in Sources */,
-				28267F1768EAB54408E429A9CF5266C6 /* NSObject+RACLifting.m in Sources */,
-				CC91DF85A57E66D95F2DD4EEBAC72616 /* NSObject+RACPropertySubscribing.m in Sources */,
-				F654A3B54ED61A3675AF5339669325C4 /* NSObject+RACSelectorSignal.m in Sources */,
-				2E77177C311D4E4217B83333D757E455 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
-				7DD41EC24DCBF7F396DFBF4F8142B140 /* NSSet+RACSequenceAdditions.m in Sources */,
-				117838CF30541E7549A84F0B861D57F3 /* NSString+RACKeyPathUtilities.m in Sources */,
-				12AC412E2B8023A469F1F1D9B7EA97CB /* NSString+RACSequenceAdditions.m in Sources */,
-				C2F6597E8A77EF42E0C6AE6CD67518B4 /* NSString+RACSupport.m in Sources */,
-				4EDF95D86C801D5FA857B842B8CB1F9B /* NSURLConnection+RACSupport.m in Sources */,
-				CC440CB4F1FCBBB64A3174300604957E /* NSUserDefaults+RACSupport.m in Sources */,
-				F52F543CEE31C49C214060DA0DC7D1D1 /* Pods-iOSDemo-ReactiveCocoa-dummy.m in Sources */,
-				CC87593D2856E1E7CE681BC8A1AB6C42 /* RACArraySequence.m in Sources */,
-				8A20843217CBA1F7196B770057AFDBBB /* RACBehaviorSubject.m in Sources */,
-				32D4F57BAFC0C0377A4914C474B87002 /* RACBlockTrampoline.m in Sources */,
-				77F0A13A96C01843151AC16CE2D020B4 /* RACChannel.m in Sources */,
-				E5F0D20923C38AE82F45DF7C5AA31DFD /* RACCommand.m in Sources */,
-				5186936C592D5714199ECE1DB1600694 /* RACCompoundDisposable.m in Sources */,
-				50A6DD77E62565139B4A97F71415518A /* RACCompoundDisposableProvider.d in Sources */,
-				58ED09797CBA8D881B4C57A3DAE9070B /* RACDelegateProxy.m in Sources */,
-				1E10DEFD4AD626CCBFC47E1159CA7CFB /* RACDisposable.m in Sources */,
-				EC38403AE69F0AEE5E0D4434938721F8 /* RACDynamicSequence.m in Sources */,
-				7DD692C6CBA1A44CBC8E54F38FCEECAE /* RACDynamicSignal.m in Sources */,
-				DE1B201210DC99DE14B077F06CEB8040 /* RACEXTRuntimeExtensions.m in Sources */,
-				DBAE21DAA93A065D4EDA26E9C72016DA /* RACEagerSequence.m in Sources */,
-				885E685B4CF13BDAF6F9250C1B4F6BC2 /* RACEmptySequence.m in Sources */,
-				CF4C09E6F0F582644A94DD51D8156B53 /* RACEmptySignal.m in Sources */,
-				04493BB4A2553AC5D92B7A9A1388E55C /* RACErrorSignal.m in Sources */,
-				44403C605B6A1121251D7E3B0D8FAB6A /* RACEvent.m in Sources */,
-				5EEDF0E415F27F1CD7170E80D4A1A53E /* RACGroupedSignal.m in Sources */,
-				2C264B5C8F6776CDE6538A836DCCEB2E /* RACImmediateScheduler.m in Sources */,
-				24F861853DA13D7FB6EBEFA21D4083FC /* RACIndexSetSequence.m in Sources */,
-				9C4778D1D001A6917C0F9D72861F2A47 /* RACKVOChannel.m in Sources */,
-				A7673271D54761D066C4C225EB224DDC /* RACKVOProxy.m in Sources */,
-				A2A5238C209B39E6E88D936564B5DD92 /* RACKVOTrampoline.m in Sources */,
-				FB511AD6FAEB27A798A15FDD60C19B9F /* RACMulticastConnection.m in Sources */,
-				1BBD20301BB50514BF3CBD450F8D9E68 /* RACObjCRuntime.m in Sources */,
-				C2C168015D8DDD9ACA11CF4C8CDA1482 /* RACPassthroughSubscriber.m in Sources */,
-				7A6362EB95723806AAFFAAC4BE134312 /* RACQueueScheduler.m in Sources */,
-				04C802A4009E3F33AF734C4248209CD3 /* RACReplaySubject.m in Sources */,
-				173A58EBADA35C9BD1FC64F457314B32 /* RACReturnSignal.m in Sources */,
-				072BBEECB0AF70587DCA35FD3614DC72 /* RACScheduler.m in Sources */,
-				F2D432F6D3AED58B095DE065518FC1E9 /* RACScopedDisposable.m in Sources */,
-				4B775DF18FFF140F096EE8FEC1184D1D /* RACSequence.m in Sources */,
-				ABD827397762B410A562EAB26622F46E /* RACSerialDisposable.m in Sources */,
-				11D9C2AE678238BC6F2A094E260181F6 /* RACSignal+Operations.m in Sources */,
-				DD53650F3F73D5955D52D5FC17DD4171 /* RACSignal.m in Sources */,
-				2620ED8A661CB605A5912C97E95BF0D0 /* RACSignalProvider.d in Sources */,
-				9BCFEE39AE69B50A2B088BB8AC9A116D /* RACSignalSequence.m in Sources */,
-				E4A0569C284D1C19B3FF97C682FB6F99 /* RACStream.m in Sources */,
-				552C3A8041B24FB88A8A54D791A310CF /* RACStringSequence.m in Sources */,
-				EB2DF82B5F37DE4C2B8EB5B1C56FFF38 /* RACSubject.m in Sources */,
-				5B3C2F91DA7BC335753CF3B36BFBA727 /* RACSubscriber.m in Sources */,
-				EB4B41B7329030EDB64235231E663E72 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
-				257DD208AB2103E51A400E95C4EDE3E6 /* RACSubscriptionScheduler.m in Sources */,
-				956C243D00CA6A064877B971360EF8CB /* RACTargetQueueScheduler.m in Sources */,
-				73FCD525B57C27216D637C608E9C7FE1 /* RACTestScheduler.m in Sources */,
-				F81849FF166E4B69915729698BFCB179 /* RACTuple.m in Sources */,
-				7B206881D7FA6BC12B1165D9EBAD10F7 /* RACTupleSequence.m in Sources */,
-				E1AE899E237F3F7D95192D335829133C /* RACUnarySequence.m in Sources */,
-				0615987B7222B50AAAC39BECF79ABCEA /* RACUnit.m in Sources */,
-				42DBE946489C3AC45B9A44AB09739B8C /* RACValueTransformer.m in Sources */,
-				2F2080BD405753BCF3C77726B3517A49 /* UIActionSheet+RACSignalSupport.m in Sources */,
-				A5CB23F880C916C1EA78643DE622FC6B /* UIAlertView+RACSignalSupport.m in Sources */,
-				5F7CD4512FAB26E8A61754C56D1A6C59 /* UIBarButtonItem+RACCommandSupport.m in Sources */,
-				E31B75AC69BE523CFC734C8406E84487 /* UIButton+RACCommandSupport.m in Sources */,
-				CD109B8928865058119F6505B12261E1 /* UICollectionReusableView+RACSignalSupport.m in Sources */,
-				2D40B189FA309BD848794351DD899909 /* UIControl+RACSignalSupport.m in Sources */,
-				EC0F98CCD35E83CBB321D6778905E0AA /* UIControl+RACSignalSupportPrivate.m in Sources */,
-				B60E619CED2D37BE2BCE83E5E4403A99 /* UIDatePicker+RACSignalSupport.m in Sources */,
-				662E0805BD85C32F854E04F394C50BD0 /* UIGestureRecognizer+RACSignalSupport.m in Sources */,
-				F8016BAB7AE47A7E4AFA4C1D8B04AE6F /* UIImagePickerController+RACSignalSupport.m in Sources */,
-				E2B4499601411FBACF8BAA68DDDD6DB5 /* UIRefreshControl+RACCommandSupport.m in Sources */,
-				8565585705C62F10FE4B1D2DF37F3737 /* UISegmentedControl+RACSignalSupport.m in Sources */,
-				321289F34B72864D84E033AC0F4D0C16 /* UISlider+RACSignalSupport.m in Sources */,
-				2E09607764F22EE25BE69BBC6D06C320 /* UIStepper+RACSignalSupport.m in Sources */,
-				977DE2B63690BA6ABCABB0FF6CA0BE54 /* UISwitch+RACSignalSupport.m in Sources */,
-				C0BA3DCD1621E156227E83D035594149 /* UITableViewCell+RACSignalSupport.m in Sources */,
-				5D605B5FD603E10D9EB566636A5F92E7 /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */,
-				5EDA2D13B1C038D12A386C3DDC73B3D4 /* UITextField+RACSignalSupport.m in Sources */,
-				108DA8AD7857AE0A1935E411FDE90474 /* UITextView+RACSignalSupport.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FFCB11E08EBA4CF3D7FBA4F4B491357A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2DC97FBB131A1BB341BCC5E6ADE269A6 /* TUSafariActivity-dummy.m in Sources */,
-				E006465E24C7D37A06DD18D3A1A2E908 /* TUSafariActivity.m in Sources */,
+				B5C5602D0DBD1A138212F8C299B619B9 /* Pods-OSXDemo-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1135BB5E89A0BA788232B66511D8B09C /* PBXTargetDependency */ = {
+		01B382303B410BFA0894ECCB97FD4843 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Pods-OSXDemo-ReactiveViewModel";
-			target = 9E3A92FD611AB2837032C6A078B63997 /* Pods-OSXDemo-ReactiveViewModel */;
-			targetProxy = 2BCE507CFD83FE61C719D50B98E76926 /* PBXContainerItemProxy */;
+			name = "Pods-iOSDemo-ReactiveCocoa";
+			target = B673783A58522C909E63B68F082A7522 /* Pods-iOSDemo-ReactiveCocoa */;
+			targetProxy = DA53E3E84D4A25961922E644A5A47A0E /* PBXContainerItemProxy */;
 		};
-		1525B3604ADFB8F5D318220C9FD45775 /* PBXTargetDependency */ = {
+		01F3C3688BF931F414BB56745112CB68 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-OSXDemo-ReactiveCocoa";
+			target = E718017CE7E7390CCB4CD9E0316ACBA4 /* Pods-OSXDemo-ReactiveCocoa */;
+			targetProxy = C8970D126C66A7F9390B54A06097DA41 /* PBXContainerItemProxy */;
+		};
+		2A54DCEEAA05D37A328E2B0091022B7F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-iOSDemo-ReactiveViewModel";
-			target = 4C01D71208D4320C07AEB2B7EDE0AE11 /* Pods-iOSDemo-ReactiveViewModel */;
-			targetProxy = 9CE570169A39FDDA54B84F03831F1283 /* PBXContainerItemProxy */;
+			target = F2CD58A8C0273CF22017094FB7192EAF /* Pods-iOSDemo-ReactiveViewModel */;
+			targetProxy = 5731401371CA314765D3E4CBB923758A /* PBXContainerItemProxy */;
 		};
-		222B4E155EFA132FE66AE358DD8204DA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = TUSafariActivity;
-			target = AB01AC1E73965EF7EE34F8FE343665F7 /* TUSafariActivity */;
-			targetProxy = 4CD613A3706B197F08280D8905E3A51F /* PBXContainerItemProxy */;
-		};
-		67B61A9C308CEB348CC9B8B8313BCF4A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-iOSDemo-ReactiveCocoa";
-			target = C2D9DA1C1FD5024961E405263D6146C5 /* Pods-iOSDemo-ReactiveCocoa */;
-			targetProxy = AA1BF2ED2898A66A248FCC937C2E14FC /* PBXContainerItemProxy */;
-		};
-		6DEFA770A5072019E821DFF105444E38 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-OSXDemo-ReactiveCocoa";
-			target = FBE0B85B81D9A77E4EC5D824DFA329F2 /* Pods-OSXDemo-ReactiveCocoa */;
-			targetProxy = 811C4AF8A18AEEC4D3DE6A1299235D40 /* PBXContainerItemProxy */;
-		};
-		A02CBDF3E422AD4180D3CC5DEEDF4AE2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-iOSDemo-ReactiveCocoa";
-			target = C2D9DA1C1FD5024961E405263D6146C5 /* Pods-iOSDemo-ReactiveCocoa */;
-			targetProxy = 80009A738447417DF31EADE20BEBC4E2 /* PBXContainerItemProxy */;
-		};
-		A62F99A89A5EE8001DFEBED5611232C2 /* PBXTargetDependency */ = {
+		34EB2E386DCCB8534D57FCF4E859A0D7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "TUSafariActivity-TUSafariActivity";
-			target = 1CBAE1D2F2A5C12C0997DEC34CD1DA08 /* TUSafariActivity-TUSafariActivity */;
-			targetProxy = 266E57AE8F3C502CE1325CD8D1A0B73A /* PBXContainerItemProxy */;
+			target = 8991DEA8DD1EB144E05885B3DBEFF046 /* TUSafariActivity-TUSafariActivity */;
+			targetProxy = F1D1138DAD5519B0A0251298362683B6 /* PBXContainerItemProxy */;
 		};
-		C4835EB4A66AC25D868043AF20D8E576 /* PBXTargetDependency */ = {
+		456F2B4B5736007E6A70AB038D7C7479 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-OSXDemo-ReactiveCocoa";
-			target = FBE0B85B81D9A77E4EC5D824DFA329F2 /* Pods-OSXDemo-ReactiveCocoa */;
-			targetProxy = 6961191592DA9073CBB9E3E4359BDBE0 /* PBXContainerItemProxy */;
+			target = E718017CE7E7390CCB4CD9E0316ACBA4 /* Pods-OSXDemo-ReactiveCocoa */;
+			targetProxy = 7FDAB1E10B3AD5A9A03679E40FD68017 /* PBXContainerItemProxy */;
 		};
-		CF999BB1D0E554D82B69C39D0823C0C0 /* PBXTargetDependency */ = {
+		62B0FC8F1502860E79CFA4F7DFC5234F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ARChromeActivity;
-			target = F9609BB655C4B4B12EA7438D41309D59 /* ARChromeActivity */;
-			targetProxy = 1DC48034B040E9F29627C06B7D6C1372 /* PBXContainerItemProxy */;
+			target = F7AF14DD2431C8DA79F45F4F1D22075E /* ARChromeActivity */;
+			targetProxy = EAA7D1EA3BD4A89CB1BDD02789C953E5 /* PBXContainerItemProxy */;
+		};
+		7F56E59B95C9EC656EEE8815FC247E71 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-OSXDemo-ReactiveViewModel";
+			target = 5D7F92A58C11C2893698E38921495622 /* Pods-OSXDemo-ReactiveViewModel */;
+			targetProxy = B56EFBB2E2BEFA4D6D88F53B8368C4C5 /* PBXContainerItemProxy */;
+		};
+		961D1EEC48DA470CC9975BD154DC7B99 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-iOSDemo-ReactiveCocoa";
+			target = B673783A58522C909E63B68F082A7522 /* Pods-iOSDemo-ReactiveCocoa */;
+			targetProxy = 09B19A76A354E7CB0E03BC43F9178D0B /* PBXContainerItemProxy */;
+		};
+		EA2452DAC41618857983FB7F9CF6F315 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = TUSafariActivity;
+			target = F46241A63E3DAF75A95934F35E3D4B07 /* TUSafariActivity */;
+			targetProxy = AA5592C351C589CF0232BA1ECE94E96F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		03DD7BE1F2202E924AA12A6571BE16BE /* Release */ = {
+		731FFEDB0C55BA9C08F165383F69F0D8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 89B1E455857D830E6B9D0113F96F2D48 /* Pods-iOSDemo.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		053E9FEA5BE7C34A830338AE0DA3CDE1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5AC54F503BAFAE36F032D4A927FDA326 /* TUSafariActivity-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				PRODUCT_NAME = TUSafariActivity;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
-		069F65576B61101224EE6B13320C93F2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5AC54F503BAFAE36F032D4A927FDA326 /* TUSafariActivity-Private.xcconfig */;
+			baseConfigurationReference = 023707F4D1F3F4E8DCE0F0A8DDC4704F /* TUSafariActivity.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				PRODUCT_NAME = TUSafariActivity;
@@ -2123,173 +2087,25 @@
 			};
 			name = Debug;
 		};
-		2B5D83FA47B7463C306DC0563F9D260F /* Release */ = {
+		8698B651179ABF20A2255A1F0BBC4EE6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 894CFD9649A3459DD133C375212142FA /* Pods-iOSDemo-ReactiveViewModel-Private.xcconfig */;
+			baseConfigurationReference = A8B9291624E54577E8A2B92078724D9D /* Pods-iOSDemo-ReactiveViewModel.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		353F7EB1C744E1FFF477B4834F429C0A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 71542763296C6D0C0B5E0CDF83B59F20 /* Pods-OSXDemo-ReactiveCocoa-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				EXECUTABLE_PREFIX = lib;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa-prefix.pch";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Debug;
-		};
-		3AEF5124D810F024D4F6AFE4603FE407 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF6D9559B18EB2D5592A1B0B4FA52A22 /* Pods-iOSDemo.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
-		52E46D8D2EB14D09B63FAA4C9DB8A1DE /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5AC54F503BAFAE36F032D4A927FDA326 /* TUSafariActivity-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/TUSafariActivity/TUSafariActivity-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		5CB004FCEA5914B02FC0CA42702AF6FF /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 71542763296C6D0C0B5E0CDF83B59F20 /* Pods-OSXDemo-ReactiveCocoa-Private.xcconfig */;
-			buildSettings = {
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				EXECUTABLE_PREFIX = lib;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa-prefix.pch";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
-		6DE19ABA442BFDFB1FBD904F30DDB746 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A56A315A07398300294330C778796CF8 /* Pods-OSXDemo-ReactiveViewModel-Private.xcconfig */;
-			buildSettings = {
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				EXECUTABLE_PREFIX = lib;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel-prefix.pch";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
-		82DA62EA9A8DEAA7ACF012834E23CA90 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A56A315A07398300294330C778796CF8 /* Pods-OSXDemo-ReactiveViewModel-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				EXECUTABLE_PREFIX = lib;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel-prefix.pch";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Debug;
-		};
-		9013B15399414859651E0B9FFAB03581 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		91E832A6ECA752A86F9EE06B5B97AFB8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = ED900941E1DC1ABFB5B06F715C48ECDF /* Pods-OSXDemo.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				EXECUTABLE_PREFIX = lib;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		9A24C4031CC22BFD9A271660AD18F843 /* Debug */ = {
+		8C89ADA2A74E7D81099169B681513743 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2321,7 +2137,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -2329,93 +2145,14 @@
 			};
 			name = Debug;
 		};
-		AB1844DDDBCE53159CEBDEA18A82A306 /* Debug */ = {
+		8DDF67D8E6B7391FCD13A67712D402D9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 894CFD9649A3459DD133C375212142FA /* Pods-iOSDemo-ReactiveViewModel-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		CD8143A1AFEA065288316B4A18069603 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5AC54F503BAFAE36F032D4A927FDA326 /* TUSafariActivity-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/TUSafariActivity/TUSafariActivity-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		D246F1DAFE707B43C68D3775FD64388B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E276A41B5D96BAB853B977C537E223C6 /* Pods-iOSDemo-ReactiveCocoa-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		D96A5EDABCE8502A73A1860547A06291 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AEFE7B6B45C74503DEA67CBE7139D37 /* ARChromeActivity-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/ARChromeActivity/ARChromeActivity-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		ED392BCA8BE1BEAAA17E4AEFB41B5691 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E276A41B5D96BAB853B977C537E223C6 /* Pods-iOSDemo-ReactiveCocoa-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		FD8A5CCC46F7E23CC1777CA65D6CD913 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE5C78EC2315BB1CC10727CDF3A338ED /* Pods-OSXDemo.release.xcconfig */;
+			baseConfigurationReference = 54ED4B2C5C52611104E3F7E352C89ACC /* Pods-OSXDemo.release.xcconfig */;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				EXECUTABLE_PREFIX = lib;
+				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
@@ -2427,9 +2164,64 @@
 			};
 			name = Release;
 		};
-		FE2EDEB5B9821B58FDF661DA8FA0A6CC /* Debug */ = {
+		8F8C790C16D1C1BE32B71C6AAEFC7246 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AEFE7B6B45C74503DEA67CBE7139D37 /* ARChromeActivity-Private.xcconfig */;
+			baseConfigurationReference = E366FD03168029DA75C718E058A8EDC8 /* ARChromeActivity.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/ARChromeActivity/ARChromeActivity-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		90839EBF14A986761D97C733A7E480D5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 023707F4D1F3F4E8DCE0F0A8DDC4704F /* TUSafariActivity.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/TUSafariActivity/TUSafariActivity-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		96882E3FDC1D10FD2F8755B03F9EC17E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0A405F68FB8ADD2325247C946DE6BBE2 /* Pods-OSXDemo-ReactiveCocoa.xcconfig */;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa-prefix.pch";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		9C95955823834364A139CB5682E1D16B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E366FD03168029DA75C718E058A8EDC8 /* ARChromeActivity.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/ARChromeActivity/ARChromeActivity-prefix.pch";
@@ -2437,20 +2229,257 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9D00C99E01152C4EB33D3D70E95BE87D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 023707F4D1F3F4E8DCE0F0A8DDC4704F /* TUSafariActivity.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/TUSafariActivity/TUSafariActivity-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9E0357AA087FF2F9314A46D873514A44 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E4D9DBFB608C04F750360D207CB52017 /* Pods-iOSDemo.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		B1CCF437EFDBD8AA09C1FC7523973736 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B3E761FC415D2B9E761E335DCB3A4425 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CE1CC2F4F712805D1D9AF43C881D944 /* Pods-OSXDemo-ReactiveViewModel.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel-prefix.pch";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		BDCA9B55EDB865D56C7DFBD3075F72A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 56463C80746C7F6187B968577A3272BD /* Pods-OSXDemo.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		C489F20DA8BCCFF6F0B48C6BECCD18F9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD3A50687D01BB54B2123BCA4E847B64 /* Pods-iOSDemo-ReactiveCocoa.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		CA065983AEB96D5A5168E902EF168159 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 023707F4D1F3F4E8DCE0F0A8DDC4704F /* TUSafariActivity.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = TUSafariActivity;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		D395228ACC1A74A3EB66ECE206FE860E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 236BC9E5E8DB36DE30265798B9BAF73A /* Pods-iOSDemo.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
+		E49530D0E706645FF11718DAE9B431A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CE1CC2F4F712805D1D9AF43C881D944 /* Pods-OSXDemo-ReactiveViewModel.xcconfig */;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel-prefix.pch";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		E8984A23BEAB76547A56343617B38B7D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0A405F68FB8ADD2325247C946DE6BBE2 /* Pods-OSXDemo-ReactiveCocoa.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa-prefix.pch";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		F779D20B770E2095C044D2C14905F625 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD3A50687D01BB54B2123BCA4E847B64 /* Pods-iOSDemo-ReactiveCocoa.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FE46F4E7C6F128E32C1D548F7A1D1198 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A8B9291624E54577E8A2B92078724D9D /* Pods-iOSDemo-ReactiveViewModel.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1ED95250274DA9BA765A8B63A10EB223 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveCocoa" */ = {
+		0769708EDA53D8336E6B8B69595B889F /* Build configuration list for PBXNativeTarget "ARChromeActivity" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D246F1DAFE707B43C68D3775FD64388B /* Debug */,
-				ED392BCA8BE1BEAAA17E4AEFB41B5691 /* Release */,
+				9C95955823834364A139CB5682E1D16B /* Debug */,
+				8F8C790C16D1C1BE32B71C6AAEFC7246 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		183A912B16DFBE337AC287C1350607C0 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BDCA9B55EDB865D56C7DFBD3075F72A8 /* Debug */,
+				8DDF67D8E6B7391FCD13A67712D402D9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2458,80 +2487,71 @@
 		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9A24C4031CC22BFD9A271660AD18F843 /* Debug */,
-				9013B15399414859651E0B9FFAB03581 /* Release */,
+				8C89ADA2A74E7D81099169B681513743 /* Debug */,
+				B1CCF437EFDBD8AA09C1FC7523973736 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5AA93334CEAC2CC1C362CE01DCF3F7D4 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveViewModel" */ = {
+		31C5EDC8C779F85C75EFCFADB4B89AF1 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveViewModel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				82DA62EA9A8DEAA7ACF012834E23CA90 /* Debug */,
-				6DE19ABA442BFDFB1FBD904F30DDB746 /* Release */,
+				8698B651179ABF20A2255A1F0BBC4EE6 /* Debug */,
+				FE46F4E7C6F128E32C1D548F7A1D1198 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		63606FD5D8D96F1CA0C3213D349D5B17 /* Build configuration list for PBXNativeTarget "TUSafariActivity" */ = {
+		50A8E47049F6D1795D91C99793433FF1 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				52E46D8D2EB14D09B63FAA4C9DB8A1DE /* Debug */,
-				CD8143A1AFEA065288316B4A18069603 /* Release */,
+				D395228ACC1A74A3EB66ECE206FE860E /* Debug */,
+				9E0357AA087FF2F9314A46D873514A44 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		674B028282083A5C14D43F6039243211 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveViewModel" */ = {
+		544C02D5C08A031625E4E6E1311689E2 /* Build configuration list for PBXNativeTarget "TUSafariActivity" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AB1844DDDBCE53159CEBDEA18A82A306 /* Debug */,
-				2B5D83FA47B7463C306DC0563F9D260F /* Release */,
+				9D00C99E01152C4EB33D3D70E95BE87D /* Debug */,
+				90839EBF14A986761D97C733A7E480D5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		780AACAF55955E4BBBCA1B3B38621195 /* Build configuration list for PBXNativeTarget "ARChromeActivity" */ = {
+		6191D12FF34563FBC0A1278CE80D2C15 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveCocoa" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FE2EDEB5B9821B58FDF661DA8FA0A6CC /* Debug */,
-				D96A5EDABCE8502A73A1860547A06291 /* Release */,
+				E8984A23BEAB76547A56343617B38B7D /* Debug */,
+				96882E3FDC1D10FD2F8755B03F9EC17E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7C72E7E03D32B9518683E75329470212 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo" */ = {
+		6B8C3065457B0DBCBC9EC8904C4D8CB6 /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveViewModel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				91E832A6ECA752A86F9EE06B5B97AFB8 /* Debug */,
-				FD8A5CCC46F7E23CC1777CA65D6CD913 /* Release */,
+				B3E761FC415D2B9E761E335DCB3A4425 /* Debug */,
+				E49530D0E706645FF11718DAE9B431A3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D08CD3818880127C91B673353C43239E /* Build configuration list for PBXNativeTarget "Pods-OSXDemo-ReactiveCocoa" */ = {
+		8121FC6604E1415DF7EAA38136F62F82 /* Build configuration list for PBXNativeTarget "TUSafariActivity-TUSafariActivity" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				353F7EB1C744E1FFF477B4834F429C0A /* Debug */,
-				5CB004FCEA5914B02FC0CA42702AF6FF /* Release */,
+				731FFEDB0C55BA9C08F165383F69F0D8 /* Debug */,
+				CA065983AEB96D5A5168E902EF168159 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DC4459C6E7D097C196B4E8E8AD6DEC8D /* Build configuration list for PBXNativeTarget "TUSafariActivity-TUSafariActivity" */ = {
+		DEFC0F41C21BF7D28B8FD9CE9372E4EA /* Build configuration list for PBXNativeTarget "Pods-iOSDemo-ReactiveCocoa" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				069F65576B61101224EE6B13320C93F2 /* Debug */,
-				053E9FEA5BE7C34A830338AE0DA3CDE1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		EAF05411A51D727F4B0BF78330076B45 /* Build configuration list for PBXNativeTarget "Pods-iOSDemo" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3AEF5124D810F024D4F6AFE4603FE407 /* Debug */,
-				03DD7BE1F2202E924AA12A6571BE16BE /* Release */,
+				F779D20B770E2095C044D2C14905F625 /* Debug */,
+				C489F20DA8BCCFF6F0B48C6BECCD18F9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pods/Target Support Files/ARChromeActivity/ARChromeActivity-Private.xcconfig
+++ b/Pods/Target Support Files/ARChromeActivity/ARChromeActivity-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "ARChromeActivity.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ARChromeActivity" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Pods/Target Support Files/ARChromeActivity/ARChromeActivity.xcconfig
+++ b/Pods/Target Support Files/ARChromeActivity/ARChromeActivity.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ARChromeActivity" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa-Private.xcconfig
+++ b/Pods/Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "Pods-OSXDemo-ReactiveCocoa.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveCocoa" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa.xcconfig
+++ b/Pods/Target Support Files/Pods-OSXDemo-ReactiveCocoa/Pods-OSXDemo-ReactiveCocoa.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveCocoa" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel-Private.xcconfig
+++ b/Pods/Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "Pods-OSXDemo-ReactiveViewModel.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveViewModel" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel.xcconfig
+++ b/Pods/Target Support Files/Pods-OSXDemo-ReactiveViewModel/Pods-OSXDemo-ReactiveViewModel.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveViewModel" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-OSXDemo/Pods-OSXDemo-frameworks.sh
+++ b/Pods/Target Support Files/Pods-OSXDemo/Pods-OSXDemo-frameworks.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
+
+install_framework()
+{
+  if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$1"
+  elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$(basename "$1")"
+  elif [ -r "$1" ]; then
+    local source="$1"
+  fi
+
+  local destination="${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+  if [ -L "${source}" ]; then
+      echo "Symlinked..."
+      source="$(readlink "${source}")"
+  fi
+
+  # use filter instead of exclude so missing patterns dont' throw errors
+  echo "rsync -av --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${source}\" \"${destination}\""
+  rsync -av --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${destination}"
+
+  local basename
+  basename="$(basename -s .framework "$1")"
+  binary="${destination}/${basename}.framework/${basename}"
+  if ! [ -r "$binary" ]; then
+    binary="${destination}/${basename}"
+  fi
+
+  # Strip invalid architectures so "fat" simulator / device frameworks work on device
+  if [[ "$(file "$binary")" == *"dynamically linked shared library"* ]]; then
+    strip_invalid_archs "$binary"
+  fi
+
+  # Resign the code if required by the build settings to avoid unstable apps
+  code_sign_if_enabled "${destination}/$(basename "$1")"
+
+  # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
+  if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then
+    local swift_runtime_libs
+    swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\/\(.+dylib\).*/\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
+    for lib in $swift_runtime_libs; do
+      echo "rsync -auv \"${SWIFT_STDLIB_PATH}/${lib}\" \"${destination}\""
+      rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+      code_sign_if_enabled "${destination}/${lib}"
+    done
+  fi
+}
+
+# Signs a framework with the provided identity
+code_sign_if_enabled() {
+  if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
+    # Use the current code_sign_identitiy
+    echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
+    echo "/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\""
+    /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
+  fi
+}
+
+# Strip invalid architectures
+strip_invalid_archs() {
+  binary="$1"
+  # Get architectures for current file
+  archs="$(lipo -info "$binary" | rev | cut -d ':' -f1 | rev)"
+  stripped=""
+  for arch in $archs; do
+    if ! [[ "${VALID_ARCHS}" == *"$arch"* ]]; then
+      # Strip non-valid architectures in-place
+      lipo -remove "$arch" -output "$binary" "$binary" || exit 1
+      stripped="$stripped $arch"
+    fi
+  done
+  if [[ "$stripped" ]]; then
+    echo "Stripped $binary of architectures:$stripped"
+  fi
+}
+

--- a/Pods/Target Support Files/Pods-OSXDemo/Pods-OSXDemo-resources.sh
+++ b/Pods/Target Support Files/Pods-OSXDemo/Pods-OSXDemo-resources.sh
@@ -60,7 +60,7 @@ install_resource()
 
 mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
-if [[ "${ACTION}" == "install" ]]; then
+if [[ "${ACTION}" == "install" ]] && [[ "${SKIP_INSTALL}" == "NO" ]]; then
   mkdir -p "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi

--- a/Pods/Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-Private.xcconfig
+++ b/Pods/Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "Pods-iOSDemo-ReactiveCocoa.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveCocoa" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa.xcconfig
+++ b/Pods/Target Support Files/Pods-iOSDemo-ReactiveCocoa/Pods-iOSDemo-ReactiveCocoa.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveCocoa" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-Private.xcconfig
+++ b/Pods/Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "Pods-iOSDemo-ReactiveViewModel.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveViewModel" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel.xcconfig
+++ b/Pods/Target Support Files/Pods-iOSDemo-ReactiveViewModel/Pods-iOSDemo-ReactiveViewModel.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveViewModel" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-frameworks.sh
+++ b/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-frameworks.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
+
+install_framework()
+{
+  if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$1"
+  elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$(basename "$1")"
+  elif [ -r "$1" ]; then
+    local source="$1"
+  fi
+
+  local destination="${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+  if [ -L "${source}" ]; then
+      echo "Symlinked..."
+      source="$(readlink "${source}")"
+  fi
+
+  # use filter instead of exclude so missing patterns dont' throw errors
+  echo "rsync -av --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${source}\" \"${destination}\""
+  rsync -av --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${destination}"
+
+  local basename
+  basename="$(basename -s .framework "$1")"
+  binary="${destination}/${basename}.framework/${basename}"
+  if ! [ -r "$binary" ]; then
+    binary="${destination}/${basename}"
+  fi
+
+  # Strip invalid architectures so "fat" simulator / device frameworks work on device
+  if [[ "$(file "$binary")" == *"dynamically linked shared library"* ]]; then
+    strip_invalid_archs "$binary"
+  fi
+
+  # Resign the code if required by the build settings to avoid unstable apps
+  code_sign_if_enabled "${destination}/$(basename "$1")"
+
+  # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
+  if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then
+    local swift_runtime_libs
+    swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\/\(.+dylib\).*/\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
+    for lib in $swift_runtime_libs; do
+      echo "rsync -auv \"${SWIFT_STDLIB_PATH}/${lib}\" \"${destination}\""
+      rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+      code_sign_if_enabled "${destination}/${lib}"
+    done
+  fi
+}
+
+# Signs a framework with the provided identity
+code_sign_if_enabled() {
+  if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
+    # Use the current code_sign_identitiy
+    echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
+    echo "/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\""
+    /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
+  fi
+}
+
+# Strip invalid architectures
+strip_invalid_archs() {
+  binary="$1"
+  # Get architectures for current file
+  archs="$(lipo -info "$binary" | rev | cut -d ':' -f1 | rev)"
+  stripped=""
+  for arch in $archs; do
+    if ! [[ "${VALID_ARCHS}" == *"$arch"* ]]; then
+      # Strip non-valid architectures in-place
+      lipo -remove "$arch" -output "$binary" "$binary" || exit 1
+      stripped="$stripped $arch"
+    fi
+  done
+  if [[ "$stripped" ]]; then
+    echo "Stripped $binary of architectures:$stripped"
+  fi
+}
+

--- a/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-resources.sh
+++ b/Pods/Target Support Files/Pods-iOSDemo/Pods-iOSDemo-resources.sh
@@ -78,7 +78,7 @@ fi
 
 mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
-if [[ "${ACTION}" == "install" ]]; then
+if [[ "${ACTION}" == "install" ]] && [[ "${SKIP_INSTALL}" == "NO" ]]; then
   mkdir -p "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi

--- a/Pods/Target Support Files/TUSafariActivity/TUSafariActivity-Private.xcconfig
+++ b/Pods/Target Support Files/TUSafariActivity/TUSafariActivity-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "TUSafariActivity.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/TUSafariActivity" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Pods/Target Support Files/TUSafariActivity/TUSafariActivity.xcconfig
+++ b/Pods/Target Support Files/TUSafariActivity/TUSafariActivity.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/TUSafariActivity" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/ARChromeActivity" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/ReactiveViewModel" "${PODS_ROOT}/Headers/Public/TUSafariActivity"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES


### PR DESCRIPTION
#### Use the correct version format

The most current pod specs for [ReactiveCocoa](https://github.com/CocoaPods/Specs/tree/master/Specs/ReactiveCocoa) and [ReactiveViewModel](https://github.com/CocoaPods/Specs/tree/master/Specs/ReactiveViewModel) omit a trailing `.0`. 
