### PR TITLE
Fix: only import properties that exist on the destination entity

### DIFF
--- a/BBFrameworks/BBCoreData/NSManagedObjectContext+BBCoreDataImportExtensions.m
+++ b/BBFrameworks/BBCoreData/NSManagedObjectContext+BBCoreDataImportExtensions.m
@@ -94,11 +94,16 @@ static void *kBB_defaultDateFormatterKey = &kBB_defaultDateFormatterKey;
         BBLog(@"created entity %@ with identity %@",entityName,identity);
     }
     
+    NSEntityDescription *entityDescription = [NSEntityDescription entityForName:entityName inManagedObjectContext:self];
+    
     [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *JSONKey, id JSONValue, BOOL *stop) {
         NSString *const kPropertyKey = [propertyMapping entityPropertyKeyForJSONKey:JSONKey entityName:entityName];
-        id const kPropertyValue = [propertyMapping entityPropertyValueForEntityPropertyKey:kPropertyKey value:JSONValue entityName:entityName context:self];
         
-        [retval setValue:kPropertyValue forKey:kPropertyKey];
+        if (entityDescription.propertiesByName[kPropertyKey] != nil) {
+            id const kPropertyValue = [propertyMapping entityPropertyValueForEntityPropertyKey:kPropertyKey value:JSONValue entityName:entityName context:self];
+            [retval setValue:kPropertyValue forKey:kPropertyKey];
+        }
+        
     }];
     
     return retval;


### PR DESCRIPTION
When importing an entity, make sure the destination property contains an entity with the name of the propertyKey you are attempting to assing a value. Without this change, the app will crash if there's a JSON key that does not exist in the core data entity

My initial thinking was that this check should exist in the `propertyMapping` objects `-entityPropertyKeyForJSONKey:entityName:` method, but in order to check if the property exists, that method requires access to an `NSManagedObjectContext`
